### PR TITLE
Qkern status

### DIFF
--- a/examples/qft/qft-utils.c
+++ b/examples/qft/qft-utils.c
@@ -40,7 +40,7 @@ void full_qft_circuit(const size_t NQUBITS, qubit * qr) {
   return;
 }
 
-void zero_init_full_qft(
+cq_status zero_init_full_qft(
 const size_t NQUBITS, qubit * qr, cstate * cr, qkern_map * reg) {
   CQ_REGISTER_KERNEL(reg)
 
@@ -53,10 +53,10 @@ const size_t NQUBITS, qubit * qr, cstate * cr, qkern_map * reg) {
   // Measure
   measure_qureg(qr, NQUBITS, cr);
   
-  return;
+  return CQ_SUCCESS;
 }
 
-void plus_init_full_qft(
+cq_status plus_init_full_qft(
 const size_t NQUBITS, qubit * qr, cstate * cr, qkern_map * reg) {
   CQ_REGISTER_KERNEL(reg);
 
@@ -72,5 +72,5 @@ const size_t NQUBITS, qubit * qr, cstate * cr, qkern_map * reg) {
   // Measure
   measure_qureg(qr, NQUBITS, cr);
 
-  return;
+  return CQ_SUCCESS;
 }

--- a/examples/qft/qft.h
+++ b/examples/qft/qft.h
@@ -6,9 +6,9 @@
 void report_results(cstate const * const CR, const size_t NMEASURE, 
   const size_t NSHOTS);
 void full_qft_circuit(const size_t NQUBITS, qubit * qr);
-void zero_init_full_qft(const size_t NQUBITS, qubit * qr, cstate * cr,
+cq_status zero_init_full_qft(const size_t NQUBITS, qubit * qr, cstate * cr,
   qkern_map * reg);
-void plus_init_full_qft(const size_t NQUBITS, qubit * qr, cstate * cr, 
+cq_status plus_init_full_qft(const size_t NQUBITS, qubit * qr, cstate * cr, 
   qkern_map * reg);
 
 #endif

--- a/include/datatypes.h
+++ b/include/datatypes.h
@@ -13,7 +13,8 @@ struct qkern_params;
 typedef enum cq_status {
   CQ_ERROR = -1,
   CQ_SUCCESS = 0,
-  CQ_WARNING = 1
+  CQ_WARNING = 1,
+  CQ_EARLY_SUCCESS
 } cq_status;
 
 typedef short int cstate;

--- a/include/datatypes.h
+++ b/include/datatypes.h
@@ -39,11 +39,11 @@ typedef struct exec {
 struct qkern_map;
 struct pqkern_map;
 
-typedef void (*qkern)
+typedef cq_status (*qkern)
   (const size_t NQUBITS, qubit * qreg, cstate * creg, 
   struct qkern_map * registration);
 
-typedef void (*pqkern)
+typedef cq_status (*pqkern)
   (const size_t NQUBITS, qubit * qreg, cstate * creg, void * params, 
   struct pqkern_map * registration);
 

--- a/include/datatypes.h
+++ b/include/datatypes.h
@@ -29,11 +29,16 @@ typedef struct exec {
   bool exec_init;
   bool complete;
   cq_status status;
+  size_t nqubits;
   size_t completed_shots;
   size_t expected_shots;
+  size_t nmeasure;
   pthread_mutex_t lock;
   pthread_cond_t cond_exec_complete;
-  struct qkern_params * qk_pars;
+  char * fname;
+  qubit * qreg;
+  cstate * creg;
+  void * params;
 } cq_exec;
 
 struct qkern_map;

--- a/include/device_ops.h
+++ b/include/device_ops.h
@@ -14,7 +14,7 @@ cq_status set_qureg_cstate(qubit * qrp, cstate const * const CRP, const size_t N
 
 // Control
 
-cq_status qabort(const unsigned int STATUS);
+cq_status qabort(const int STATUS);
 
 // Measurements
 

--- a/include/kernel_utils.h
+++ b/include/kernel_utils.h
@@ -12,9 +12,10 @@ if (reg != NULL) {\
   size_t strsz = sizeof(__func__);\
   if (strsz < __CQ_MAX_QKERN_NAME_LENGTH__) {\
     strcpy(reg->fname, __func__);\
-    return;\
+    return CQ_SUCCESS;\
   } else {\
     reg->fname[0] = '\0';\
+    return CQ_ERROR;\
   }\
 }
 

--- a/include/kernel_utils.h
+++ b/include/kernel_utils.h
@@ -32,14 +32,6 @@ struct pqkern_registry {
 extern struct qkern_registry qk_reg;
 extern struct pqkern_registry pqk_reg;
 
-typedef struct qkern_params {
-  size_t nqubits;
-  char * fname;
-  qubit * qreg;
-  cstate * creg;
-  void * params;
-} qkern_params;
-
 // Kernel registration
 
 cq_status register_qkern(qkern kernel);
@@ -58,7 +50,7 @@ cq_status find_pqkern_name(pqkern const PQK, char ** fname);
 
 // set exec handles
 
-void init_exec_handle(const size_t NSHOTS, cq_exec * ehp);
+void init_exec_handle(const size_t NQUBITS, const size_t NSHOTS, const size_t NMEASURE, cq_exec * ehp);
 
 void finalise_exec_handle(cq_exec * ehp);
 

--- a/src/device/control.c
+++ b/src/device/control.c
@@ -6,7 +6,7 @@
 #include "resources.h"
 #include "quest/include/environment.h"
 
-int (*control_registry[8])(void *) =  {
+cq_status (*control_registry[8])(void *) =  {
   initialise_simulator,
   abort_current_kernel,
   finalise_simulator,
@@ -17,47 +17,61 @@ int (*control_registry[8])(void *) =  {
   test_control_fn
 };
 
-int initialise_simulator(void * par) {
-  const unsigned int * pVERBOSITY = (const unsigned int *) par;
-
-  if (*pVERBOSITY > 0) {
-    printf("Initialising QuEST.\n");
-  }
-
-  initQuESTEnv();
-
-  if (*pVERBOSITY > 0) {
-    reportQuESTEnv();
+cq_status initialise_simulator(void * par) {
+  cq_status status = CQ_WARNING;
   
-    printf("Initialising quantum resource registry.\n");
-  }
-
-  init_qregistry();
-
   // isQuESTEnvInit returns 1 for true, 0 for false
-  return !isQuESTEnvInit();
-}
+  if (!isQuESTEnvInit()) {
+    const unsigned int * pVERBOSITY = (const unsigned int *) par;
 
-int abort_current_kernel(void * par) {
-  return 0;
-}
+    if (*pVERBOSITY > 0) {
+      printf("Initialising QuEST.\n");
+    }
 
-int finalise_simulator(void * par) {
-  const unsigned int * pVERBOSITY = (const unsigned int *) par;
+    initQuESTEnv();
+
+    if (*pVERBOSITY > 0) {
+      reportQuESTEnv();
+    
+      printf("Initialising quantum resource registry.\n");
+    }
+
+    init_qregistry();
   
-  if (*pVERBOSITY > 0) {
-    printf("Finalising QuEST\n");
+    status = isQuESTEnvInit() - 1;
   }
 
-  clear_qregistry();
-
-  finalizeQuESTEnv();
-
-  // isQuESTEnvInit returns 1 for true, 0 for false
-  return isQuESTEnvInit();
+  return status;
 }
 
-int run_qkernel(void * par) {
+cq_status abort_current_kernel(void * par) {
+  return CQ_ERROR;
+}
+
+cq_status finalise_simulator(void * par) {
+  cq_status status = CQ_WARNING;
+
+  if (isQuESTEnvInit()) {
+    const unsigned int * pVERBOSITY = (const unsigned int *) par;
+    
+    if (*pVERBOSITY > 0) {
+      printf("Finalising QuEST\n");
+    }
+
+    clear_qregistry();
+
+    finalizeQuESTEnv();
+
+    // isQuESTEnvInit returns 1 for true, 0 for false
+    if (!isQuESTEnvInit()) {
+      status = CQ_SUCCESS;
+    }
+  }
+
+  return status;
+}
+
+cq_status run_qkernel(void * par) {
   qkern_params * qk_par = (qkern_params*) par;
 
   // find local function pointer
@@ -66,13 +80,13 @@ int run_qkernel(void * par) {
 
   // run it!
   if (!status) {
-    qk(qk_par->nqubits, qk_par->qreg, qk_par->creg, NULL);
+    status = qk(qk_par->nqubits, qk_par->qreg, qk_par->creg, NULL);
   }
 
   return status;
 }
 
-int run_pqkernel(void * par) {
+cq_status run_pqkernel(void * par) {
   qkern_params * pqk_par = (qkern_params*) par;
 
   // find local function pointer
@@ -81,13 +95,13 @@ int run_pqkernel(void * par) {
 
   // run it!
   if (!status) {
-    pqk(pqk_par->nqubits, pqk_par->qreg, pqk_par->creg, pqk_par->params, NULL);
+    status = pqk(pqk_par->nqubits, pqk_par->qreg, pqk_par->creg, pqk_par->params, NULL);
   }
 
  return status;
 }
 
-int test_control_fn(void * par) {
+cq_status test_control_fn(void * par) {
   unsigned int * p_test_count = (unsigned int *) par;
 
   (*p_test_count)++;

--- a/src/device/control.h
+++ b/src/device/control.h
@@ -1,18 +1,18 @@
 #ifndef DEVICE_CONTROL_H
 #define DEVICE_CONTROL_H
 
-extern int (*control_registry[8])(void *);
+extern cq_status (*control_registry[8])(void *);
 
-int initialise_simulator(void *);
+cq_status initialise_simulator(void *);
 
-int abort_current_kernel(void *);
+cq_status abort_current_kernel(void *);
 
-int finalise_simulator(void *);
+cq_status finalise_simulator(void *);
 
-int run_qkernel(void *);
+cq_status run_qkernel(void *);
 
-int run_pqkernel(void *);
+cq_status run_pqkernel(void *);
 
-int test_control_fn(void *);
+cq_status test_control_fn(void *);
 
 #endif 

--- a/src/device/device_ops.c
+++ b/src/device/device_ops.c
@@ -81,6 +81,26 @@ cq_status set_qureg_cstate(qubit * qrp, cstate const * const CRP, const size_t N
   return status;
 }
 
+// Control
+
+cq_status qabort(const int STATUS) {
+  // if there's anything we could do within the
+  // kernel to ensure graceful exit, we should do it
+  // here
+  // (currently there is not)
+
+  // at least make sure we don't return success,
+  // because the kernel runner won't end execution
+  // if we do
+
+  cq_status status = STATUS;
+  if (STATUS == CQ_SUCCESS) {
+    status = CQ_EARLY_SUCCESS;
+  }
+
+  return status;
+}
+
 // Measurements
 
 cq_status dmeasure_qubit(qubit * qbp, cstate * csp) {

--- a/src/host-device/comms.c
+++ b/src/host-device/comms.c
@@ -97,8 +97,18 @@ size_t device_sync_exec(const cq_status STATUS, const size_t SHOT,
 cstate const * const RESULT, cq_exec * ehp) {
   pthread_mutex_lock(&ehp->lock);
   
-  ehp->status = STATUS;
+  if (STATUS == CQ_EARLY_SUCCESS) {
+    // generally speaking we should respect the kernel-provided
+    // status code, but CQ_EARLY_SUCCESS really means CQ_SUCCESS
+    // but needed to be != so we could break execution
+    ehp->status = CQ_SUCCESS;
+  } else {
+    ehp->status = STATUS;
+  }
+  
   ehp->completed_shots += 1;
+
+  printf("%s: STATUS = %d, ehp->completed_shots = %lu\n", __func__, STATUS, ehp->completed_shots);
 
   // copy local result register to exec
   cstate * dest_creg = ehp->creg + SHOT * ehp->nmeasure;

--- a/src/host-device/comms.c
+++ b/src/host-device/comms.c
@@ -158,21 +158,25 @@ void * device_control_thread(void * par) {
 
     // handle exec handle if present
     if (current_exec_handle != NULL && current_exec_handle->exec_init) {
-      pthread_mutex_lock(&(current_exec_handle->lock));
-      ++(current_exec_handle->completed_shots);
-      // if all shots are complete
-      if (
-        current_exec_handle->completed_shots ==
-        current_exec_handle->expected_shots
-      ) {
-        current_exec_handle->status = status;
-        current_exec_handle->complete = true;
-        pthread_cond_signal(&(current_exec_handle->cond_exec_complete));
+      if (status == CQ_SUCCESS) {  
+        pthread_mutex_lock(&(current_exec_handle->lock));
+        ++(current_exec_handle->completed_shots);
+        // if all shots are complete
+        if (
+          current_exec_handle->completed_shots ==
+          current_exec_handle->expected_shots
+        ) {
+          current_exec_handle->status = status;
+          current_exec_handle->complete = true;
+          pthread_cond_signal(&(current_exec_handle->cond_exec_complete));
+        } else {
+          // use warning status to indicate partial completion
+          current_exec_handle->status = CQ_WARNING;
+        }
+        pthread_mutex_unlock(&(current_exec_handle->lock));
       } else {
-        // use warning status to indicate partial completion
-        current_exec_handle->status = CQ_WARNING;
+        // kernel reports something has gone wrong!
       }
-      pthread_mutex_unlock(&(current_exec_handle->lock));
     }
   }  
  

--- a/src/host-device/comms.h
+++ b/src/host-device/comms.h
@@ -24,7 +24,6 @@ struct dev_link {
   size_t next_op_out;
   enum ctrl_code op_buffer[__CQ_DEVICE_QUEUE_SIZE__];
   void * op_params_buffer[__CQ_DEVICE_QUEUE_SIZE__];
-  cq_exec * exec_handle_buffer[__CQ_DEVICE_QUEUE_SIZE__];
 };
 
 typedef struct device_alloc_params {
@@ -39,14 +38,14 @@ int initialise_device(const unsigned int VERBOSITY);
 
 size_t host_send_ctrl_op(const enum ctrl_code OP, void * ctrl_params);
 
-size_t host_send_exec(const enum ctrl_code OP, cq_exec * const ehp,
-  const size_t SHOT);
-
 size_t host_sync_exec(cq_exec * const ehp);
 
 size_t host_wait_exec(cq_exec * const ehp);
 
 size_t host_wait_all_ops();
+
+size_t device_sync_exec(const cq_status STATUS, const size_t SHOT, 
+  cstate const * const RESULT, cq_exec * ehp);
 
 void * device_control_thread(void *);
 

--- a/src/host/host_ops.c
+++ b/src/host/host_ops.c
@@ -189,13 +189,9 @@ cq_status sync_qrun(cq_exec * const ehp) {
 cq_status wait_qrun(cq_exec * const ehp) {
   cq_status status = CQ_ERROR;
   if (ehp != NULL && ehp->exec_init) {
-    size_t shots_completed = host_wait_exec(ehp);
-    if (shots_completed == ehp->expected_shots) {
-      status = CQ_SUCCESS;
-    } else {
-      status = CQ_WARNING;
-    }
+    host_wait_exec(ehp);
     finalise_exec_handle(ehp);
+    status = CQ_SUCCESS;
   } else if (ehp != NULL && ehp->expected_shots == 0) {
     status = CQ_SUCCESS;
     ehp->status = CQ_SUCCESS;

--- a/src/host/host_ops.c
+++ b/src/host/host_ops.c
@@ -168,6 +168,8 @@ cq_exec * const ehp) {
         ehp->qk_pars[shot].creg = crp + shot * NMEASURE;
         ehp->qk_pars[shot].params = NULL;
         host_send_exec(CQ_CTRL_RUN_QKERNEL, ehp, shot);
+
+        // check exec status here
       }
     }
 

--- a/src/host/host_ops.c
+++ b/src/host/host_ops.c
@@ -85,22 +85,15 @@ cq_status free_qureg(qubit ** qrp) {
 cq_status s_qrun(qkern kernel, qubit * qrp, const size_t NQUBITS,
 cstate * crp, const size_t NMEASURE) {
   cq_status status = CQ_ERROR;
-  char * fname = NULL;
+  cq_exec exec_handle;
 
-  if (qrp != NULL && (NMEASURE == 0 || crp != NULL)) {
-    status = find_qkern_name(kernel, &fname);
+  status = a_qrun(kernel, qrp, NQUBITS, crp, NMEASURE, &exec_handle);
+  
+  if (status == CQ_SUCCESS) {
+    status = wait_qrun(&exec_handle);
 
     if (status == CQ_SUCCESS) {
-      qkern_params qk_pars;
-
-      qk_pars.nqubits = NQUBITS;
-      qk_pars.fname = fname;
-      qk_pars.creg = crp;
-      qk_pars.qreg = qrp;
-      qk_pars.params = NULL;
-
-      host_send_ctrl_op(CQ_CTRL_RUN_QKERNEL, &qk_pars);
-      host_wait_all_ops();
+      status = exec_handle.status;
     }
   }
 
@@ -136,30 +129,16 @@ cstate * crp, const size_t NMEASURE, cq_exec * const ehp) {
 
 cq_status sm_qrun(qkern kernel, qubit * qrp, const size_t NQUBITS, 
 cstate * const crp, const size_t NMEASURE, const size_t NSHOTS) {
+  cq_exec exec_handle;
   cq_status status = CQ_ERROR;
-  char * fname = NULL;
 
-  // proceed iff there are any shots
-  // and the qreg is non-null
-  // and either the creg is non-null or there will be no measurements anyway
-  if (NSHOTS == 0) {
-    status = CQ_SUCCESS;
-  } else if (qrp != NULL && (NMEASURE == 0 || crp != NULL)) {
-    status = find_qkern_name(kernel, &fname);    
+  status = am_qrun(kernel, qrp, NQUBITS, crp, NMEASURE, NSHOTS, &exec_handle);
+
+  if (status == CQ_SUCCESS) {
+    status = wait_qrun(&exec_handle);
 
     if (status == CQ_SUCCESS) {
-      // safe because we wait on all ops before exiting this function
-      qkern_params qk_pars[NSHOTS];   
-
-      for (size_t shot = 0; shot < NSHOTS; ++shot) {
-        qk_pars[shot].nqubits = NQUBITS;
-        qk_pars[shot].fname = fname;
-        qk_pars[shot].creg = crp + shot * NMEASURE;
-        qk_pars[shot].qreg = qrp;
-        qk_pars[shot].params = NULL;
-        host_send_ctrl_op(CQ_CTRL_RUN_QKERNEL, &qk_pars[shot]);
-      }
-      host_wait_all_ops();
+      status = exec_handle.status;
     }
   }
 
@@ -220,6 +199,9 @@ cq_status wait_qrun(cq_exec * const ehp) {
       status = CQ_WARNING;
     }
     finalise_exec_handle(ehp);
+  } else if (ehp != NULL && ehp->expected_shots == 0) {
+    status = CQ_SUCCESS;
+    ehp->status = CQ_SUCCESS;
   }
   return status;
 }

--- a/src/host/host_ops.c
+++ b/src/host/host_ops.c
@@ -105,20 +105,19 @@ cstate * crp, const size_t NMEASURE, cq_exec * const ehp) {
   cq_status status = CQ_ERROR;
   char * fname = NULL;
 
-  // init_exec_handle will malloc qkern_param array
-  init_exec_handle(1, ehp);
+  init_exec_handle(NQUBITS, 1, NMEASURE, ehp);
 
   if (qrp != NULL && (NMEASURE == 0 || crp != NULL)) {
     status = find_qkern_name(kernel, &fname);
 
     if (status == CQ_SUCCESS) {
-      ehp->qk_pars[0].nqubits = NQUBITS;
-      ehp->qk_pars[0].fname = fname;
-      ehp->qk_pars[0].creg = crp;
-      ehp->qk_pars[0].qreg = qrp;
-      ehp->qk_pars[0].params = NULL;
+      ehp->fname = fname;
+      ehp->qreg = qrp;
+      ehp->creg = crp;
 
-      host_send_exec(CQ_CTRL_RUN_QKERNEL, ehp, 0);
+      host_send_ctrl_op(CQ_CTRL_RUN_QKERNEL, ehp);
+    } else {
+      finalise_exec_handle(ehp);
     }
   } else {
     finalise_exec_handle(ehp);
@@ -152,7 +151,7 @@ cq_exec * const ehp) {
   char * fname = NULL;
 
   // init_exec_handle will malloc qkern_param array
-  init_exec_handle(NSHOTS, ehp);
+  init_exec_handle(NQUBITS, NSHOTS, NMEASURE, ehp);
 
   if (NSHOTS == 0) {
     status = CQ_SUCCESS;
@@ -161,16 +160,12 @@ cq_exec * const ehp) {
     status = find_qkern_name(kernel, &fname);
 
     if (status == CQ_SUCCESS) {
-      for (size_t shot = 0; shot < NSHOTS; ++shot) {
-        ehp->qk_pars[shot].nqubits = NQUBITS;
-        ehp->qk_pars[shot].fname = fname;
-        ehp->qk_pars[shot].qreg = qrp;
-        ehp->qk_pars[shot].creg = crp + shot * NMEASURE;
-        ehp->qk_pars[shot].params = NULL;
-        host_send_exec(CQ_CTRL_RUN_QKERNEL, ehp, shot);
-
-        // check exec status here
-      }
+      ehp->fname = fname;
+      ehp->qreg = qrp;
+      ehp->creg = crp;
+      host_send_ctrl_op(CQ_CTRL_RUN_QKERNEL, ehp);
+    } else {
+      finalise_exec_handle(ehp);
     }
 
   } else {

--- a/tests/device/test_device_control.c
+++ b/tests/device/test_device_control.c
@@ -23,6 +23,7 @@ void test_initialise_simulator(void) {
   TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, initialise_simulator((void*) &VERBOSE));
   TEST_ASSERT(isQuESTEnvInit());
   TEST_ASSERT_EQUAL_size_t(0, qregistry.num_registers);
+  TEST_ASSERT_EQUAL_INT(CQ_WARNING, initialise_simulator((void *) &VERBOSE));
 
   return;
 }
@@ -77,6 +78,8 @@ void test_finalise_simulator(void) {
   TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, finalise_simulator((void*) &VERBOSE));
   TEST_ASSERT_FALSE(isQuESTEnvInit());
   TEST_ASSERT_EQUAL_size_t(0, qregistry.num_registers);
+
+  TEST_ASSERT_EQUAL_INT(CQ_WARNING, finalise_simulator((void *) &VERBOSE));
 
   return;
 }

--- a/tests/device/test_device_control.c
+++ b/tests/device/test_device_control.c
@@ -47,24 +47,20 @@ void test_run_qkernel(void) {
 
   TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, register_qkern(zero_init_full_qft));
 
-  qkern_params qkp_ur = {
-    .fname = "unregistered_kernel",
-    .nqubits = NQUBITS,
-    .qreg = qr,
-    .creg = cr,
-    .params = NULL
-  };
+  cq_exec ex_ur;
+  init_exec_handle(NQUBITS, 1, NQUBITS, &ex_ur);
+  ex_ur.fname = "unregistered_kernel";
+  ex_ur.qreg = qr;
+  ex_ur.creg = cr;
 
-  qkern_params qkp_zqft = {
-    .fname = "zero_init_full_qft",
-    .nqubits = NQUBITS,
-    .qreg = qr,
-    .creg = cr,
-    .params = NULL
-  };
+  cq_exec ex_zqft;
+  init_exec_handle(NQUBITS, 1, NQUBITS, &ex_zqft);
+  ex_zqft.fname = "zero_init_full_qft";
+  ex_zqft.qreg = qr;
+  ex_zqft.creg = cr;
 
-  TEST_ASSERT_EQUAL_INT(CQ_ERROR, run_qkernel((void*) &qkp_ur));
-  TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, run_qkernel((void*) &qkp_zqft));
+  TEST_ASSERT_EQUAL_INT(CQ_ERROR, run_qkernel((void*) &ex_ur));
+  TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, run_qkernel((void*) &ex_zqft));
 
   TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, device_dealloc_qureg((void*) &dap));
 

--- a/tests/device/test_device_ops.c
+++ b/tests/device/test_device_ops.c
@@ -125,6 +125,17 @@ void test_qureg_setters(void) {
   return;
 }
 
+void test_qabort(void) {
+  const int TEST_STATUS = 666;
+  const int TEST_STATUS2 = -666;
+
+  TEST_ASSERT_EQUAL_INT(TEST_STATUS, qabort(TEST_STATUS));
+  TEST_ASSERT_EQUAL_INT(TEST_STATUS2, qabort(TEST_STATUS2));
+  TEST_ASSERT_EQUAL_INT(CQ_EARLY_SUCCESS, qabort(CQ_SUCCESS));
+
+  return;
+}
+
 void test_qureg_measure(void) {
   // the d/non-d functions are in fact identical
   char msg[32];

--- a/tests/device/test_device_ops.h
+++ b/tests/device/test_device_ops.h
@@ -2,6 +2,7 @@
 #define CQ_TEST_DEVICE_OPS_H
 
 void test_qureg_setters(void);
+void test_qabort(void);
 void test_qureg_measure(void);
 
 #endif

--- a/tests/device/test_device_ops_runner.c
+++ b/tests/device/test_device_ops_runner.c
@@ -9,6 +9,7 @@ int main (void)
   cq_init(0);
 
   RUN_TEST(test_qureg_setters);
+  RUN_TEST(test_qabort);
   RUN_TEST(test_qureg_measure);
 
   cq_finalise(0);

--- a/tests/host-device/test_kernel_utils.c
+++ b/tests/host-device/test_kernel_utils.c
@@ -17,8 +17,8 @@ void test_register_qkern(void) {
   TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, register_qkern(zero_init_full_qft));
   TEST_ASSERT_EQUAL_PTR(zero_init_full_qft, qk_reg.qkernels[0].fn);
   TEST_ASSERT_EQUAL_size_t(1, qk_reg.next_available_slot);
-  TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, register_qkern(equal_superposition_full_qft));
-  TEST_ASSERT_EQUAL_PTR(equal_superposition_full_qft, qk_reg.qkernels[1].fn);
+  TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, register_qkern(plus_init_full_qft));
+  TEST_ASSERT_EQUAL_PTR(plus_init_full_qft, qk_reg.qkernels[1].fn);
   TEST_ASSERT_EQUAL_size_t(2, qk_reg.next_available_slot);
   TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, register_qkern(all_site_hadamard));
   TEST_ASSERT_EQUAL_PTR(all_site_hadamard, qk_reg.qkernels[2].fn);

--- a/tests/host-device/test_kernel_utils.c
+++ b/tests/host-device/test_kernel_utils.c
@@ -89,16 +89,23 @@ void test_find_qkern_name(void) {
 }
 
 void test_init_and_finalise_exec_handle(void) {
-  const size_t NSHOTS = 10;
+  const size_t NQUBITS = 8;
+  const size_t NSHOTS = 100;
+  const size_t NMEASURE = 4;
   cq_exec eh;
 
-  init_exec_handle(NSHOTS, &eh);
+  init_exec_handle(NQUBITS, NSHOTS, NMEASURE, &eh);
   TEST_ASSERT(eh.exec_init);
   TEST_ASSERT_FALSE(eh.complete);
   TEST_ASSERT_EQUAL_INT(CQ_ERROR, eh.status);
+  TEST_ASSERT_EQUAL_size_t(NQUBITS, eh.nqubits);
   TEST_ASSERT_EQUAL_size_t(0, eh.completed_shots);
   TEST_ASSERT_EQUAL_size_t(NSHOTS, eh.expected_shots);
-  TEST_ASSERT_NOT_NULL(eh.qk_pars);
+  TEST_ASSERT_EQUAL_size_t(NMEASURE, eh.nmeasure);
+  TEST_ASSERT_NULL(eh.fname);
+  TEST_ASSERT_NULL(eh.qreg);
+  TEST_ASSERT_NULL(eh.creg);
+  TEST_ASSERT_NULL(eh.params);
 
   finalise_exec_handle(&eh);
   TEST_ASSERT_FALSE(eh.exec_init);
@@ -106,7 +113,6 @@ void test_init_and_finalise_exec_handle(void) {
   TEST_ASSERT_EQUAL_INT(CQ_ERROR, eh.status);
   TEST_ASSERT_EQUAL_size_t(0, eh.completed_shots);
   TEST_ASSERT_EQUAL_size_t(NSHOTS, eh.expected_shots);
-  TEST_ASSERT_NULL(eh.qk_pars);
   
   return;
 }

--- a/tests/host/test_executors.c
+++ b/tests/host/test_executors.c
@@ -360,7 +360,7 @@ void test_nshots(void) {
   TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
     am_qrun(zero_init_full_qft, NULL, NQUBITS, NULL, NMEASURE, nshots, &eh)
   );
-  TEST_ASSERT_EQUAL_INT(CQ_ERROR, wait_qrun(&eh));
+  TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, wait_qrun(&eh));
 
   qubit * qr = NULL;
   alloc_qureg(&qr, NQUBITS);

--- a/tests/host/test_executors.c
+++ b/tests/host/test_executors.c
@@ -77,14 +77,14 @@ void test_first_run(void) {
   init_creg(NMEASURE, CR_INIT_VAL, cr);
   TEST_ASSERT_EACH_EQUAL_INT16(CR_INIT_VAL, cr, NMEASURE);
   TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
-    s_qrun(equal_superposition_full_qft, qr, NQUBITS, cr, NMEASURE)
+    s_qrun(plus_init_full_qft, qr, NQUBITS, cr, NMEASURE)
   );
   TEST_ASSERT_INT16_ARRAY_WITHIN(1, expected, cr, NMEASURE);
 
   init_creg(NMEASURE, CR_INIT_VAL, cr);
   TEST_ASSERT_EACH_EQUAL_INT16(CR_INIT_VAL, cr, NMEASURE);
   TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
-    a_qrun(equal_superposition_full_qft, qr, NQUBITS, cr, NMEASURE, &eh)
+    a_qrun(plus_init_full_qft, qr, NQUBITS, cr, NMEASURE, &eh)
   );
   TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, wait_qrun(&eh));
   TEST_ASSERT_FALSE(eh.exec_init);
@@ -95,13 +95,13 @@ void test_first_run(void) {
 
   init_creg(NMEASURE*NSHOTS, CR_INIT_VAL, cr);
   TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
-    sm_qrun(equal_superposition_full_qft, qr, NQUBITS, cr, NMEASURE, NSHOTS)
+    sm_qrun(plus_init_full_qft, qr, NQUBITS, cr, NMEASURE, NSHOTS)
   );
   TEST_ASSERT_INT16_ARRAY_WITHIN(1, expected, cr, NMEASURE*NSHOTS);
 
   init_creg(NMEASURE*NSHOTS, CR_INIT_VAL, cr);
   TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
-    am_qrun(equal_superposition_full_qft, qr, NQUBITS, cr, NMEASURE, NSHOTS, 
+    am_qrun(plus_init_full_qft, qr, NQUBITS, cr, NMEASURE, NSHOTS, 
       &eh)
   );
   TEST_ASSERT(eh.exec_init);

--- a/tests/host/test_executors.h
+++ b/tests/host/test_executors.h
@@ -12,5 +12,6 @@ void test_first_run(void);
 void test_nmeasure(void);
 void test_nshots(void);
 void test_bad_inputs(void);
+void test_kernel_abort(void);
 
 #endif

--- a/tests/host/test_executors_runner.c
+++ b/tests/host/test_executors_runner.c
@@ -12,7 +12,7 @@ int main ()
 
   register_qkern(all_site_hadamard);
   register_qkern(zero_init_full_qft);
-  register_qkern(equal_superposition_full_qft);
+  register_qkern(plus_init_full_qft);
   register_qkern(only_measure_first_site);
   register_qkern(no_measure_qkern);
 

--- a/tests/host/test_executors_runner.c
+++ b/tests/host/test_executors_runner.c
@@ -15,11 +15,16 @@ int main ()
   register_qkern(plus_init_full_qft);
   register_qkern(only_measure_first_site);
   register_qkern(no_measure_qkern);
+  register_qkern(immediate_qabort);
+  register_qkern(successful_qabort);
+  register_qkern(cq_error_qabort);
+  register_qkern(custom_error_qabort);
 
   RUN_TEST(test_first_run);
   RUN_TEST(test_nmeasure);
   RUN_TEST(test_nshots);
   RUN_TEST(test_bad_inputs);
+  RUN_TEST(test_kernel_abort);
 
   cq_finalise(0);
 

--- a/tests/test_qkerns.c
+++ b/tests/test_qkerns.c
@@ -11,7 +11,7 @@
 #define M_PI 3.1415926535897932384
 #endif
 
-void qft_circuit(const size_t NQUBITS, qubit * qr) {
+cq_status qft_circuit(const size_t NQUBITS, qubit * qr) {
   // Run QFT
   for (size_t i = 0; i < NQUBITS; ++i) {
     hadamard(&qr[i]); 
@@ -27,11 +27,11 @@ void qft_circuit(const size_t NQUBITS, qubit * qr) {
     swap(&qr[i], &qr[j]);
   } 
 
-  return;
+  return CQ_SUCCESS;
 }
 
 
-void zero_init_full_qft(
+cq_status zero_init_full_qft(
 const size_t NQUBITS, qubit * qr, cstate * cr, qkern_map * reg) {
   CQ_REGISTER_KERNEL(reg)
 
@@ -44,10 +44,10 @@ const size_t NQUBITS, qubit * qr, cstate * cr, qkern_map * reg) {
   // Measure
   measure_qureg(qr, NQUBITS, cr);
   
-  return;
+  return CQ_SUCCESS;
 }
 
-void equal_superposition_full_qft(
+cq_status equal_superposition_full_qft(
 const size_t NQUBITS, qubit * qr, cstate * cr, qkern_map * reg) {
   CQ_REGISTER_KERNEL(reg);
 
@@ -63,10 +63,10 @@ const size_t NQUBITS, qubit * qr, cstate * cr, qkern_map * reg) {
   // Measure
   measure_qureg(qr, NQUBITS, cr);
 
-  return;
+  return CQ_SUCCESS;
 }
 
-void all_site_hadamard(const size_t NQUBITS, qubit * qr, cstate * cr,
+cq_status all_site_hadamard(const size_t NQUBITS, qubit * qr, cstate * cr,
 qkern_map * reg) {
   CQ_REGISTER_KERNEL(reg);
 
@@ -77,10 +77,10 @@ qkern_map * reg) {
 
   measure_qureg(qr, NQUBITS, cr);
   
-  return;
+  return CQ_SUCCESS;
 }
 
-void only_measure_first_site(const size_t NQUBITS, qubit * qr,
+cq_status only_measure_first_site(const size_t NQUBITS, qubit * qr,
 cstate * cr, qkern_map * reg) {
   CQ_REGISTER_KERNEL(reg);
 
@@ -91,25 +91,25 @@ cstate * cr, qkern_map * reg) {
   // TODO: implement with measure_qubit once implemented
   measure_qureg(qr, 1, cr);
 
-  return;
+  return CQ_SUCCESS;
 }
 
-void no_measure_qkern(const size_t NQUBITS, qubit * qr, cstate * cr,
+cq_status no_measure_qkern(const size_t NQUBITS, qubit * qr, cstate * cr,
 qkern_map * reg) {
   CQ_REGISTER_KERNEL(reg);
 
   // a tree falls in the forest with no-one to hear it...
 
-  return;
+  return CQ_SUCCESS;
 }
 
-void unregistered_kernel(const size_t NQUBITS, qubit * qr,
+cq_status unregistered_kernel(const size_t NQUBITS, qubit * qr,
 cstate * cr, qkern_map * reg) {
   printf("I'm an unregistered kernel. How did you get here?\n");
-  return;
+  return CQ_ERROR;
 }
 
-void overly_long_qkern_name(const size_t NQUBITS, qubit * qr,
+cq_status overly_long_qkern_name(const size_t NQUBITS, qubit * qr,
 cstate * cr, qkern_map * reg) {
   // "overly_long_qkern_name" is of course fine, but the string
   // we're about to build isn't!
@@ -129,8 +129,8 @@ cstate * cr, qkern_map * reg) {
     } else {
       reg->fname[0] = '\0';
     }
-    return;
+    return CQ_SUCCESS;
   }
 
-  return;
+  return CQ_SUCCESS;
 }

--- a/tests/test_qkerns.c
+++ b/tests/test_qkerns.c
@@ -47,7 +47,7 @@ const size_t NQUBITS, qubit * qr, cstate * cr, qkern_map * reg) {
   return CQ_SUCCESS;
 }
 
-cq_status equal_superposition_full_qft(
+cq_status plus_init_full_qft(
 const size_t NQUBITS, qubit * qr, cstate * cr, qkern_map * reg) {
   CQ_REGISTER_KERNEL(reg);
 

--- a/tests/test_qkerns.c
+++ b/tests/test_qkerns.c
@@ -134,3 +134,67 @@ cstate * cr, qkern_map * reg) {
 
   return CQ_SUCCESS;
 }
+
+cq_status immediate_qabort(const size_t NQUBITS, qubit * qr, cstate * cr, qkern_map * reg) {
+  CQ_REGISTER_KERNEL(reg);
+  return qabort(CQ_ERROR);
+}
+
+// these qabort kernels will abort on the FOURTH shot
+
+cq_status successful_qabort(const size_t NQUBITS, qubit * qr, cstate * cr,
+qkern_map * reg) {
+  CQ_REGISTER_KERNEL(reg);
+  const unsigned int COUNT_LIMIT = 4;
+  static unsigned int count = 0;
+
+  // "measure" into the creg
+  for (size_t i = 0; i < NQUBITS; ++i) {
+    cr[i] = 1;
+  }
+
+  printf("%s: count = %d on entry\n", __func__, count);
+
+  // increment count and abort on 4th shot (or greater)
+  if (++count >= COUNT_LIMIT) {
+    return qabort(CQ_SUCCESS);
+  }
+
+  return CQ_SUCCESS;
+}
+
+cq_status cq_error_qabort(const size_t NQUBITS, qubit * qr, cstate * cr,
+qkern_map * reg) {
+  CQ_REGISTER_KERNEL(reg);
+  const unsigned int COUNT_LIMIT = 4;
+  static unsigned int count = 0;
+
+  // "measure" into creg
+  for (size_t i = 0; i < NQUBITS; ++i) {
+    cr[i] = 1;
+  }
+
+  if (++count >= COUNT_LIMIT) {
+    return qabort(CQ_ERROR);
+  }
+
+  return CQ_SUCCESS;
+}
+
+cq_status custom_error_qabort(const size_t NQUBITS, qubit * qr, cstate * cr,
+qkern_map * reg) {
+  CQ_REGISTER_KERNEL(reg);
+  const int CUSTOM_ERROR = 666;
+  const unsigned int COUNT_LIMIT = 4;
+  static unsigned int count = 0;
+
+  for (size_t i = 0; i < NQUBITS; ++i) {
+    cr[i] = 1;
+  }
+
+  if (++count >= COUNT_LIMIT) {
+    return qabort(CUSTOM_ERROR);
+  }
+
+  return CQ_SUCCESS;
+}

--- a/tests/test_qkerns.h
+++ b/tests/test_qkerns.h
@@ -18,5 +18,13 @@ cq_status unregistered_kernel(const size_t NQUBITS, qubit * qr,
   cstate * cr, qkern_map * reg);
 cq_status overly_long_qkern_name(const size_t NQUBITS, qubit * qr,
   cstate * cr, qkern_map * reg);
+cq_status immediate_qabort(const size_t NQUBITS, qubit * qr, cstate * cr,
+  qkern_map * reg);
+cq_status successful_qabort(const size_t NQUBITS, qubit * qr,
+  cstate * cr, qkern_map * reg);
+cq_status cq_error_qabort(const size_t NQUBITS, qubit * qr,
+  cstate * cr, qkern_map * reg);
+cq_status custom_error_qabort(const size_t NQUBITS, qubit * qr,
+  cstate * cr, qkern_map * reg);
 
 #endif

--- a/tests/test_qkerns.h
+++ b/tests/test_qkerns.h
@@ -3,20 +3,20 @@
 
 #include "datatypes.h"
 
-void qft_circuit(const size_t NQUBITS, qubit * qr);
-void zero_init_full_qft(const size_t NQUBITS, qubit * qr, 
+cq_status qft_circuit(const size_t NQUBITS, qubit * qr);
+cq_status zero_init_full_qft(const size_t NQUBITS, qubit * qr, 
   cstate * cr, qkern_map * reg);
-void equal_superposition_full_qft(const size_t NQUBITS, qubit * qr,
+cq_status equal_superposition_full_qft(const size_t NQUBITS, qubit * qr,
   cstate * cr, qkern_map * reg);
-void all_site_hadamard(const size_t NQUBITS, qubit * qr,
+cq_status all_site_hadamard(const size_t NQUBITS, qubit * qr,
   cstate * cr, qkern_map * reg);
-void only_measure_first_site(const size_t NQUBITS, qubit * qr,
+cq_status only_measure_first_site(const size_t NQUBITS, qubit * qr,
   cstate * cr, qkern_map * reg);
-void no_measure_qkern(const size_t NQUBITS, qubit * qr, cstate * cr,
+cq_status no_measure_qkern(const size_t NQUBITS, qubit * qr, cstate * cr,
   qkern_map * reg);
-void unregistered_kernel(const size_t NQUBITS, qubit * qr,
+cq_status unregistered_kernel(const size_t NQUBITS, qubit * qr,
   cstate * cr, qkern_map * reg);
-void overly_long_qkern_name(const size_t NQUBITS, qubit * qr,
+cq_status overly_long_qkern_name(const size_t NQUBITS, qubit * qr,
   cstate * cr, qkern_map * reg);
 
 #endif

--- a/tests/test_qkerns.h
+++ b/tests/test_qkerns.h
@@ -6,7 +6,7 @@
 cq_status qft_circuit(const size_t NQUBITS, qubit * qr);
 cq_status zero_init_full_qft(const size_t NQUBITS, qubit * qr, 
   cstate * cr, qkern_map * reg);
-cq_status equal_superposition_full_qft(const size_t NQUBITS, qubit * qr,
+cq_status plus_init_full_qft(const size_t NQUBITS, qubit * qr,
   cstate * cr, qkern_map * reg);
 cq_status all_site_hadamard(const size_t NQUBITS, qubit * qr,
   cstate * cr, qkern_map * reg);

--- a/tests/validation/CMakeLists.txt
+++ b/tests/validation/CMakeLists.txt
@@ -3,6 +3,7 @@ find_library(MATHS_LIBRARY m REQUIRED)
 add_executable(test_qft
   test_qft_runner.c
   test_qft.c
+  ../test_qkerns.c
 )
 
 target_link_libraries(test_qft

--- a/tests/validation/test_qft.c
+++ b/tests/validation/test_qft.c
@@ -2,6 +2,7 @@
 #include <math.h>
 #include "unity.h"
 #include "cq.h"
+#include "tests/test_qkerns.h"
 
 #ifndef M_PI
 #define M_PI 3.141592653589793238462643383
@@ -24,60 +25,6 @@ void setUp(void) {
 void tearDown(void) {
   free_qureg(&qr);
   free(cr);
-  return;
-}
-
-void qft_circuit(const size_t NQUBITS, qubit * qr) {
-  // Run QFT
-  for (size_t i = 0; i < NQUBITS; ++i) {
-    hadamard(&qr[i]); 
-    for (size_t j = i+1; j < NQUBITS; ++j) {
-      double angle = M_PI / pow(2, j);
-      cphase(&qr[j], &qr[i], angle);
-    }
-  }
-
-
-  for (size_t i = 0; i < NQUBITS / 2; ++i) {
-    size_t j = NQUBITS - (i+1);
-    swap(&qr[i], &qr[j]);
-  } 
-
-  return;
-}
-
-void zero_init_full_qft(
-const size_t NQUBITS, qubit * qr, cstate * cr, qkern_map * reg) {
-  CQ_REGISTER_KERNEL(reg)
-
-  // Prepare state
-  set_qureg(qr, 0, NQUBITS);
-
-  // Run QFT
-  qft_circuit(NQUBITS, qr);
-
-  // Measure
-  measure_qureg(qr, NQUBITS, cr);
-  
-  return;
-}
-
-void equal_superposition_full_qft(
-const size_t NQUBITS, qubit * qr, cstate * cr, qkern_map * reg) {
-  CQ_REGISTER_KERNEL(reg);
-
-  // Prepare state
-  set_qureg(qr, 0, NQUBITS);
-  for (size_t i = 0; i < NQUBITS; ++i) {
-    hadamard(&qr[i]);
-  }
-
-  // Run QFT
-  qft_circuit(NQUBITS, qr);
-
-  // Measure
-  measure_qureg(qr, NQUBITS, cr);
-
   return;
 }
 
@@ -112,10 +59,10 @@ void test_zero_init_qft(void) {
 void test_plus_init_qft(void) {
   init_creg(NMEASURE * NSHOTS, -1, cr);
 
-  TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, register_qkern(equal_superposition_full_qft));
+  TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, register_qkern(plus_init_full_qft));
 
   TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, 
-    sm_qrun(equal_superposition_full_qft, qr, NQUBITS, cr, NMEASURE, NSHOTS));
+    sm_qrun(plus_init_full_qft, qr, NQUBITS, cr, NMEASURE, NSHOTS));
 
   TEST_ASSERT_EACH_EQUAL_INT16(0, cr, NMEASURE * NSHOTS);
 
@@ -124,7 +71,7 @@ void test_plus_init_qft(void) {
   cq_exec eh;
   TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, 
     am_qrun(
-      equal_superposition_full_qft, qr, NQUBITS, cr, NMEASURE, NSHOTS, &eh
+      plus_init_full_qft, qr, NQUBITS, cr, NMEASURE, NSHOTS, &eh
     )
   );
 


### PR DESCRIPTION
Implemented ability to return statuses from quantum kernels, and moved shot management to device control functions (i.e. `run_qkernel`) to avoid filling the device queue and bottlenecking. 