### PR TITLE
Added pulse-based analog extension which emulates neutral atom platform.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2025 Oliver Thomson Brown, EPCC
+Copyright (c) 2025 Mateusz Meller, Hartree Centre, STFC, UKRI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(qft)
+add_subdirectory(analog)

--- a/examples/analog/CMakeLists.txt
+++ b/examples/analog/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(qaa
+  qaa.c
+)
+
+find_library(MATHS_LIBRARY m REQUIRED)
+
+target_link_libraries(qaa
+  PRIVATE
+  CQ-SIMBE::cq-simbe
+  ${MATHS_LIBRARY}
+)

--- a/examples/analog/qaa.c
+++ b/examples/analog/qaa.c
@@ -112,7 +112,7 @@ int main (void)
   printf("Hello again, I'm done being 'useful' and will now wait for ");
   printf("the quantum device to return!\n");
 
-  wait_qrun(&eh_plus);
+  wait_qrun(&eh_maxcut);
   printf("Results from QAA:\n");
   report_results(cr_plus, NMEASURE, NSHOTS);
 

--- a/examples/analog/qaa.c
+++ b/examples/analog/qaa.c
@@ -93,14 +93,12 @@ int main (void)
   cq_init(0);
 
   cq_enable_analog_mode(RYDBERG);
-  // We will reuse the quantum buffer as the quantum
-  // kernels cannot run simultaneously (for now...)
   qubit * qr = NULL;
   alloc_qureg(&qr, NQUBITS);
 
-  cstate cr_plus[NMEASURE * NSHOTS];
+  cstate cr[NMEASURE * NSHOTS];
 
-  init_creg(NMEASURE * NSHOTS, -1, cr_plus);
+  init_creg(NMEASURE * NSHOTS, -1, cr);
 
   register_qkern(quantum_adiabatic_algo);
 
@@ -114,7 +112,7 @@ int main (void)
 
   wait_qrun(&eh_maxcut);
   printf("Results from QAA:\n");
-  report_results(cr_plus, NMEASURE, NSHOTS);
+  report_results(cr, NMEASURE, NSHOTS);
 
   free_qureg(&qr);
 

--- a/examples/analog/qaa.c
+++ b/examples/analog/qaa.c
@@ -105,7 +105,7 @@ int main (void)
   register_qkern(quantum_adiabatic_algo);
 
   printf("Offloading QAA circuit to the quantum device.\n");
-  am_qrun(quantum_adiabatic_algo, qr, NQUBITS, cr_plus, NMEASURE, NSHOTS, &eh_plus);
+  am_qrun(quantum_adiabatic_algo, qr, NQUBITS, cr, NMEASURE, NSHOTS, &eh_maxcut);
 
   printf("Hello from the host, pretend I'm doing something useful!\n");
   sleep(2);

--- a/examples/analog/qaa.c
+++ b/examples/analog/qaa.c
@@ -1,0 +1,124 @@
+/**
+ * Reproduces MAXCUT problem for 5 vertices
+ *
+ *        [-10.0, 19.7365809, 19.7365809, 5.42015853, 5.42015853],
+ *        [19.7365809, -10.0, 20.67626392, 0.17675796, 0.85604541],
+ *   Q =  [19.7365809, 20.67626392, -10.0, 0.85604541, 0.17675796],
+ *        [5.42015853, 0.17675796, 0.85604541, -10.0, 0.32306662],
+ *        [5.42015853, 0.85604541, 0.17675796, 0.32306662, -10.0],
+ *
+ * Solution to this problem are:
+ * [1, 1, 1, 0, 0] and [1, 1, 0, 1, 0]
+ *
+ * Based on https://pulser.readthedocs.io/en/stable/tutorials/qubo.html
+*/
+
+#include "cq.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
+void report_results(cstate const * const CR, const size_t NMEASURE,
+const size_t NSHOTS) {
+  printf("Reporting measurement outcomes:\n");
+  for (size_t shot = 0; shot < NSHOTS; ++shot) {
+    printf("Shot [%lu]: ", shot);
+    for (size_t i = shot * NMEASURE; i < (shot + 1) * NMEASURE; ++i) {
+      printf("%d ", CR[i]);
+    }
+    printf("\n");
+  }
+
+  return;
+};
+
+#define HANDLE_CQA_ERR(x)                           \
+        {                                           \
+            if (x == CQ_ERROR)                      \
+            {                                       \
+                printf(" From: %s\n", __func__);    \
+                return CQ_ERROR;                    \
+            }                                       \
+        };
+
+cq_status quantum_adiabatic_algo(const size_t NQUBITS, qubit *qr, cstate * cr, qkern_map * reg)
+{
+  CQ_REGISTER_KERNEL(reg);
+  set_qureg(qr, 0, NQUBITS);
+
+  int qreg_id = 0;
+  HANDLE_CQA_ERR(cq_enable_analog_qreg(qreg_id, NQUBITS));
+  channel ch0 = {0};
+  HANDLE_CQA_ERR(cq_get_global_channel(&ch0, 0, qreg_id));
+
+  pulse pulse = {0};
+  double duration = 4000.0;
+  HANDLE_CQA_ERR(cq_init_pulse(&pulse, duration));
+  double data_points[3] = {1e-9, 3.0, 1e-9};
+  int num_points = 3;
+
+  HANDLE_CQA_ERR(cq_interpolated_wf(pulse.freq, duration, data_points, num_points));
+
+  data_points[0] = -5.0;
+  data_points[1] = 0.0;
+  data_points[2] = 5.0;
+
+  HANDLE_CQA_ERR(cq_interpolated_wf(pulse.detuning, duration, data_points, num_points));
+
+  qpos positions[5] = {
+       { 5.53855359,  1.7891413 , 0.0},
+       { 5.48899179, -6.27296412, 0.0},
+       {-1.43242244, -2.26122822, 0.0},
+       { 1.62594084, 10.99193777, 0.0},
+       {15.4687696 ,  2.96846731, 0.0}};
+
+  HANDLE_CQA_ERR(cq_update_qreg_pos(positions, NQUBITS, qreg_id));
+  HANDLE_CQA_ERR(cq_play(&ch0, &pulse));
+
+  measure_qureg(qr, NQUBITS, cr);
+  HANDLE_CQA_ERR(cq_disable_analog_qreg(qreg_id));
+  return CQ_SUCCESS;
+};
+
+#undef HANDLE_CQA_ERR
+
+int main (void)
+{
+  const size_t NQUBITS = 5;
+  const size_t NSHOTS = 10;
+  const size_t NMEASURE = NQUBITS;
+
+  cq_exec eh_zero, eh_plus;
+
+  cq_init(0);
+
+  cq_enable_analog_mode(RYDBERG);
+  // We will reuse the quantum buffer as the quantum
+  // kernels cannot run simultaneously (for now...)
+  qubit * qr = NULL;
+  alloc_qureg(&qr, NQUBITS);
+
+  cstate cr_plus[NMEASURE * NSHOTS];
+
+  init_creg(NMEASURE * NSHOTS, -1, cr_plus);
+
+  register_qkern(quantum_adiabatic_algo);
+
+  printf("Offloading QAA circuit to the quantum device.\n");
+  am_qrun(quantum_adiabatic_algo, qr, NQUBITS, cr_plus, NMEASURE, NSHOTS, &eh_plus);
+
+  printf("Hello from the host, pretend I'm doing something useful!\n");
+  sleep(2);
+  printf("Hello again, I'm done being 'useful' and will now wait for ");
+  printf("the quantum device to return!\n");
+
+  wait_qrun(&eh_plus);
+  printf("Results from QAA:\n");
+  report_results(cr_plus, NMEASURE, NSHOTS);
+
+  free_qureg(&qr);
+
+  cq_finalise(0);
+
+  return 0;
+}

--- a/examples/analog/qaa.c
+++ b/examples/analog/qaa.c
@@ -88,7 +88,7 @@ int main (void)
   const size_t NSHOTS = 10;
   const size_t NMEASURE = NQUBITS;
 
-  cq_exec eh_zero, eh_plus;
+  cq_exec eh_maxcut;
 
   cq_init(0);
 

--- a/examples/analog/qaa.c
+++ b/examples/analog/qaa.c
@@ -18,52 +18,29 @@
 #include <stdio.h>
 #include <unistd.h>
 
-void report_results(cstate const * const CR, const size_t NMEASURE,
-const size_t NSHOTS) {
-  printf("Reporting measurement outcomes:\n");
-  for (size_t shot = 0; shot < NSHOTS; ++shot) {
-    printf("Shot [%lu]: ", shot);
-    for (size_t i = shot * NMEASURE; i < (shot + 1) * NMEASURE; ++i) {
-      printf("%d ", CR[i]);
-    }
-    printf("\n");
-  }
-
-  return;
-};
-
-#define HANDLE_CQA_ERR(x)                           \
-        {                                           \
-            if (x == CQ_ERROR)                      \
-            {                                       \
-                printf(" From: %s\n", __func__);    \
-                return CQ_ERROR;                    \
-            }                                       \
-        };
-
 cq_status quantum_adiabatic_algo(const size_t NQUBITS, qubit *qr, cstate * cr, qkern_map * reg)
 {
   CQ_REGISTER_KERNEL(reg);
   set_qureg(qr, 0, NQUBITS);
 
   int qreg_id = 0;
-  HANDLE_CQA_ERR(cq_enable_analog_qreg(qreg_id, NQUBITS));
+  HANDLE_CQ_ERROR(cq_enable_analog_qreg(qreg_id, NQUBITS));
   channel ch0 = {0};
-  HANDLE_CQA_ERR(cq_get_global_channel(&ch0, 0, qreg_id));
+  HANDLE_CQ_ERROR(cq_get_global_channel(&ch0, 0, qreg_id));
 
   pulse pulse = {0};
   double duration = 4000.0;
-  HANDLE_CQA_ERR(cq_init_pulse(&pulse, duration));
+  HANDLE_CQ_ERROR(cq_init_pulse(&pulse, duration));
   double data_points[3] = {1e-9, 3.0, 1e-9};
   int num_points = 3;
 
-  HANDLE_CQA_ERR(cq_interpolated_wf(pulse.freq, duration, data_points, num_points));
+  HANDLE_CQ_ERROR(cq_interpolated_wf(pulse.freq, duration, data_points, num_points));
 
   data_points[0] = -5.0;
   data_points[1] = 0.0;
   data_points[2] = 5.0;
 
-  HANDLE_CQA_ERR(cq_interpolated_wf(pulse.detuning, duration, data_points, num_points));
+  HANDLE_CQ_ERROR(cq_interpolated_wf(pulse.detuning, duration, data_points, num_points));
 
   qpos positions[5] = {
        { 5.53855359,  1.7891413 , 0.0},
@@ -72,15 +49,15 @@ cq_status quantum_adiabatic_algo(const size_t NQUBITS, qubit *qr, cstate * cr, q
        { 1.62594084, 10.99193777, 0.0},
        {15.4687696 ,  2.96846731, 0.0}};
 
-  HANDLE_CQA_ERR(cq_update_qreg_pos(positions, NQUBITS, qreg_id));
-  HANDLE_CQA_ERR(cq_play(&ch0, &pulse));
+  HANDLE_CQ_ERROR(cq_update_qreg_pos(positions, NQUBITS, qreg_id));
+  HANDLE_CQ_ERROR(cq_play(&ch0, &pulse));
 
   measure_qureg(qr, NQUBITS, cr);
-  HANDLE_CQA_ERR(cq_disable_analog_qreg(qreg_id));
+  HANDLE_CQ_ERROR(cq_disable_analog_qreg(qreg_id));
   return CQ_SUCCESS;
 };
 
-#undef HANDLE_CQA_ERR
+#undef HANDLE_CQ_ERROR
 
 int main (void)
 {

--- a/include/analog.h
+++ b/include/analog.h
@@ -1,0 +1,87 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#ifndef CQ_ANALOG_H
+#define CQ_ANALOG_H
+
+#include "datatypes.h"
+#include <stddef.h>
+
+typedef enum device_mode {
+    RYDBERG,
+    XY
+} device_mode;
+
+typedef struct qpos {
+    double x;
+    double y;
+    double z;
+} qpos;
+
+typedef struct channel {
+    int id;
+    int type;
+    int target;
+    double time;
+    void* params;
+} channel;
+
+#define __CQ_ANALOG_MAX_NUM_SAMPLES__ 4096
+typedef struct pulse {
+    double freq[__CQ_ANALOG_MAX_NUM_SAMPLES__];
+    double phase[__CQ_ANALOG_MAX_NUM_SAMPLES__];
+    double detuning[__CQ_ANALOG_MAX_NUM_SAMPLES__];
+    double duration;
+    ptrdiff_t num_samples;
+} pulse;
+
+cq_status cq_print_analog_device(void);
+cq_status cq_print_avail_channels(void);
+cq_status cq_print_channel(channel *ch);
+cq_status cq_print_qpos(int qreg_id);
+// TODO: cq_status cq_retarget_channel(channel *ch, int new_target);
+ptrdiff_t cq_duration_to_samples(double duration);
+double cq_samples_to_duration(ptrdiff_t num_samples);
+
+cq_status cq_enable_analog_mode(device_mode mode);
+cq_status cq_enable_analog_qreg(int qreg_id, int num_qubits);
+cq_status cq_disable_analog_qreg(int qreg_id);
+cq_status cq_get_global_channel(channel *ch, int type, int qreg_id);
+cq_status cq_get_local_channel(channel *ch, int type, int target, int qreg_id);
+
+cq_status cq_update_qreg_pos(const qpos *new_positions, int num_qubits, int qreg_id);
+
+cq_status cq_init_pulse(pulse *pulse, double duration);
+cq_status cq_play(channel *ch, pulse *pulse);
+cq_status cq_capture(channel *ch, pulse *pulse, int *result, int shots);
+cq_status cq_delay(channel *ch, double dt);
+cq_status cq_barrier(channel **ch, int num_channels);
+
+cq_status cq_gaussian_wf(double *samples, double duration, double amp, double sigma);
+
+// TODO: consider removing as it has limited applicability
+cq_status cq_gaussian_sqr_wf(double *samples, double duration, double amp,
+                          double sigma, double width);
+
+cq_status cq_interpolated_wf(double *samples, double duration,
+                          double *points, int num_points);
+cq_status cq_sech_wf(double *samples, double duration, double amp, double sigma);
+cq_status cq_sin_wf(double *samples, double duration, double amp,
+                 double freq, double phase);
+cq_status cq_cos_wf(double *samples, double duration, double amp,
+                 double freq, double phase);
+cq_status cq_blackman_wf(double *samples, double duration, double amp);
+cq_status cq_saw_wf(double *samples, double duration, double amp,
+                 double freq, double phase);
+cq_status cq_custom_wf(double *samples, double *values, int num_samples);
+cq_status cq_composite_wf(double *samples, double **waveforms,
+                       ptrdiff_t *num_samples, int num_waveforms,
+                       ptrdiff_t *total_num_samples);
+
+#endif

--- a/include/cq.h
+++ b/include/cq.h
@@ -1,6 +1,7 @@
 #ifndef CQ_H
 #define CQ_H
 
+#include "analog.h"
 #include "datatypes.h"
 #include "env.h"
 #include "device_ops.h"

--- a/include/utils.h
+++ b/include/utils.h
@@ -5,4 +5,18 @@
 
 void init_creg(const size_t LENGTH, const cstate INIT_VAL, cstate * cr);
 
+void report_results(
+    cstate const * const CR,
+    const size_t NMEASURE,
+    const size_t NSHOTS)
+
+#define HANDLE_CQ_ERROR(x)                           \
+        {                                           \
+            if (x == CQ_ERROR)                      \
+            {                                       \
+                printf(" From: %s\n", __func__);    \
+                return CQ_ERROR;                    \
+            }                                       \
+        };
+
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -8,7 +8,7 @@ void init_creg(const size_t LENGTH, const cstate INIT_VAL, cstate * cr);
 void report_results(
     cstate const * const CR,
     const size_t NMEASURE,
-    const size_t NSHOTS)
+    const size_t NSHOTS);
 
 #define HANDLE_CQ_ERROR(x)                           \
         {                                           \

--- a/src/device/CMakeLists.txt
+++ b/src/device/CMakeLists.txt
@@ -6,3 +6,5 @@ target_sources(cq-simbe
   resources.c
   device_utils.c
 )
+
+add_subdirectory(analog)

--- a/src/device/analog/CMakeLists.txt
+++ b/src/device/analog/CMakeLists.txt
@@ -1,0 +1,11 @@
+target_sources(cq-simbe
+	PRIVATE
+	analog_device.c
+	analog_qreg.c
+	channel.c
+	hamil.c
+	pulse.c
+	waveforms.c
+	simulator.c
+	analog.c
+)

--- a/src/device/analog/analog.c
+++ b/src/device/analog/analog.c
@@ -16,17 +16,11 @@
 #include "pulse.h"
 #include "waveforms.h"
 
+#include "utils.h"
+
 #include <stdio.h>
 
 //============================ VALIDATION =====================================
-#define HANDLE_CQA_ERR(x)                           \
-        {                                           \
-            if (x == CQ_ERROR)                      \
-            {                                       \
-                printf(" From: %s\n", __func__);    \
-                return CQ_ERROR;                    \
-            }                                       \
-        };
 
 static cq_status validate_num_qubits(int num_qubits) {
     if (num_qubits <= 0 || num_qubits > __CQ_ANALOG_MAX_NUM_QUBITS__) {
@@ -222,93 +216,93 @@ cq_status cq_enable_analog_mode(device_mode mode) {
 }
 
 cq_status cq_enable_analog_qreg(int qreg_id, int num_qubits) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(validate_qreg_id(qreg_id));
-    HANDLE_CQA_ERR(validate_num_qubits(num_qubits));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(validate_qreg_id(qreg_id));
+    HANDLE_CQ_ERROR(validate_num_qubits(num_qubits));
     return enable_analog_qreg(qreg_id, num_qubits);
 }
 
 cq_status cq_disable_analog_qreg(int qreg_id) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(validate_qreg_id(qreg_id));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(validate_qreg_id(qreg_id));
     return disable_analog_qreg(qreg_id);
 }
 
 cq_status cq_get_global_channel(channel *ch, int type, int qreg_id) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(validate_channel(ch));
-    HANDLE_CQA_ERR(validate_channel_type(type, GLOBAL));
-    HANDLE_CQA_ERR(validate_qreg_id(qreg_id));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(validate_channel(ch));
+    HANDLE_CQ_ERROR(validate_channel_type(type, GLOBAL));
+    HANDLE_CQ_ERROR(validate_qreg_id(qreg_id));
     return get_global_channel(ch, type, qreg_id);
 }
 
 cq_status cq_get_local_channel(channel *ch, int type, int target, int qreg_id) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(validate_channel(ch));
-    HANDLE_CQA_ERR(validate_channel_type(type, LOCAL));
-    HANDLE_CQA_ERR(validate_qubits_idx(target));
-    HANDLE_CQA_ERR(validate_qreg_id(qreg_id));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(validate_channel(ch));
+    HANDLE_CQ_ERROR(validate_channel_type(type, LOCAL));
+    HANDLE_CQ_ERROR(validate_qubits_idx(target));
+    HANDLE_CQ_ERROR(validate_qreg_id(qreg_id));
     return get_local_channel(ch, type, target, qreg_id);
 }
 
 cq_status cq_update_qreg_pos(const qpos *new_positions, int num_qubits, int qreg_id) {
-    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQ_ERROR(is_analog_device_init());
     if (!new_positions) {
         printf("Error: Passed nullptr positions. From: %s\n", __func__);
         return CQ_ERROR;
     }
 
-    HANDLE_CQA_ERR(validate_num_qubits(num_qubits));
-    HANDLE_CQA_ERR(validate_qreg_id(qreg_id));
+    HANDLE_CQ_ERROR(validate_num_qubits(num_qubits));
+    HANDLE_CQ_ERROR(validate_qreg_id(qreg_id));
     return update_qreg_pos(new_positions, num_qubits, qreg_id);
 }
 
 //================================ PULSE ======================================
 cq_status cq_init_pulse(pulse *pulse, double duration) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(validate_pulse(pulse));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(validate_pulse(pulse));
     return init_pulse(pulse, duration);
 }
 
 cq_status cq_play(channel *ch, pulse *pulse) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(validate_channel(ch));
-    HANDLE_CQA_ERR(validate_channel_params(ch));
-    HANDLE_CQA_ERR(validate_pulse(pulse));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(validate_channel(ch));
+    HANDLE_CQ_ERROR(validate_channel_params(ch));
+    HANDLE_CQ_ERROR(validate_pulse(pulse));
     return play(ch, pulse);
 }
 
 cq_status cq_capture(channel *ch, pulse *pulse, int *result, int shots) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(validate_channel(ch));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(validate_channel(ch));
     // can capture only with channels that have valid target
-    HANDLE_CQA_ERR(validate_channel_type(ch->type, LOCAL));
-    HANDLE_CQA_ERR(validate_channel_params(ch));
-    HANDLE_CQA_ERR(validate_pulse(pulse));
-    HANDLE_CQA_ERR(validate_result(result));
-    HANDLE_CQA_ERR(validate_num_shots(shots));
+    HANDLE_CQ_ERROR(validate_channel_type(ch->type, LOCAL));
+    HANDLE_CQ_ERROR(validate_channel_params(ch));
+    HANDLE_CQ_ERROR(validate_pulse(pulse));
+    HANDLE_CQ_ERROR(validate_result(result));
+    HANDLE_CQ_ERROR(validate_num_shots(shots));
     return capture(ch, pulse, result, shots);
 }
 
 cq_status cq_delay(channel *ch, double dt) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(validate_channel(ch));
-    HANDLE_CQA_ERR(validate_channel_params(ch));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(validate_channel(ch));
+    HANDLE_CQ_ERROR(validate_channel_params(ch));
     return delay(ch, dt);
 }
 
 cq_status cq_barrier(channel **ch, int num_channels) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(validate_channels(ch, num_channels));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(validate_channels(ch, num_channels));
     return barrier(ch, num_channels);
 }
 
 //=============================== WAVEFORMS ===================================
 
 cq_status cq_gaussian_wf(double *samples, double duration, double amp, double sigma) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(prevalidate_duration(duration));
-    HANDLE_CQA_ERR(validate_samples(samples));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(prevalidate_duration(duration));
+    HANDLE_CQ_ERROR(validate_samples(samples));
     return gaussian_wf(samples, duration, amp, sigma);
 }
 
@@ -317,7 +311,7 @@ cq_status cq_gaussian_sqr_wf(double *samples, double duration, double amp,
     printf("Error: Not implemented!\n");
     return CQ_ERROR;
 
-    HANDLE_CQA_ERR(validate_samples(samples));
+    HANDLE_CQ_ERROR(validate_samples(samples));
     if (width > duration) {
         printf("Error: Specified width would produce negative risefall. "
                "Width must be < duration. From: %s\n", __func__);
@@ -330,9 +324,9 @@ cq_status cq_gaussian_sqr_wf(double *samples, double duration, double amp,
 
 cq_status cq_interpolated_wf(double *samples, double duration,
                           double *points, int num_points) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(prevalidate_duration(duration));
-    HANDLE_CQA_ERR(validate_samples(samples));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(prevalidate_duration(duration));
+    HANDLE_CQ_ERROR(validate_samples(samples));
     if (!points) {
         printf("Error: Passed nullptr instead of array of points. "
                "From: %s\n", __func__);
@@ -350,62 +344,62 @@ cq_status cq_interpolated_wf(double *samples, double duration,
 }
 
 cq_status cq_sech_wf(double *samples, double duration, double amp, double sigma) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(prevalidate_duration(duration));
-    HANDLE_CQA_ERR(validate_samples(samples));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(prevalidate_duration(duration));
+    HANDLE_CQ_ERROR(validate_samples(samples));
     return sech_wf(samples, duration, amp, sigma);
 }
 
 cq_status cq_sin_wf(double *samples, double duration, double amp,
                  double freq, double phase) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(prevalidate_duration(duration));
-    HANDLE_CQA_ERR(validate_samples(samples));
-    HANDLE_CQA_ERR(validate_freq(freq));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(prevalidate_duration(duration));
+    HANDLE_CQ_ERROR(validate_samples(samples));
+    HANDLE_CQ_ERROR(validate_freq(freq));
     return sin_wf(samples, duration, amp,
                  freq, phase);
 }
 
 cq_status cq_cos_wf(double *samples, double duration, double amp,
                  double freq, double phase) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(prevalidate_duration(duration));
-    HANDLE_CQA_ERR(validate_samples(samples));
-    HANDLE_CQA_ERR(validate_freq(freq));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(prevalidate_duration(duration));
+    HANDLE_CQ_ERROR(validate_samples(samples));
+    HANDLE_CQ_ERROR(validate_freq(freq));
     return cos_wf(samples, duration, amp,
                  freq, phase);
 }
 
 cq_status cq_blackman_wf(double *samples, double duration, double amp) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(prevalidate_duration(duration));
-    HANDLE_CQA_ERR(validate_samples(samples));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(prevalidate_duration(duration));
+    HANDLE_CQ_ERROR(validate_samples(samples));
     return blackman_wf(samples, duration, amp);
 }
 
 cq_status cq_saw_wf(double *samples, double duration, double amp,
                  double freq, double phase) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(prevalidate_duration(duration));
-    HANDLE_CQA_ERR(validate_samples(samples));
-    HANDLE_CQA_ERR(validate_freq(freq));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(prevalidate_duration(duration));
+    HANDLE_CQ_ERROR(validate_samples(samples));
+    HANDLE_CQ_ERROR(validate_freq(freq));
     return saw_wf(samples, duration, amp,
                  freq, phase);
 }
 
 cq_status cq_custom_wf(double *samples, double *values, int num_samples) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(validate_samples(samples));
-    HANDLE_CQA_ERR(validate_values(values));
-    HANDLE_CQA_ERR(validate_num_samples(num_samples));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(validate_samples(samples));
+    HANDLE_CQ_ERROR(validate_values(values));
+    HANDLE_CQ_ERROR(validate_num_samples(num_samples));
     return custom_wf(samples, values, num_samples);
 }
 
 cq_status cq_composite_wf(double *samples, double **waveforms,
                        ptrdiff_t *num_samples, int num_waveforms,
                        ptrdiff_t *total_num_samples) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(validate_composite_wf(samples, waveforms, num_samples,
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(validate_composite_wf(samples, waveforms, num_samples,
                                          num_waveforms, total_num_samples));
     return composite_wf(samples, waveforms,
                        num_samples, num_waveforms,
@@ -413,41 +407,39 @@ cq_status cq_composite_wf(double *samples, double **waveforms,
 }
 
 cq_status cq_print_analog_device(void) {
-    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQ_ERROR(is_analog_device_init());
     print_analog_device();
     return CQ_SUCCESS;
 }
 cq_status cq_print_avail_channels(void) {
-    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQ_ERROR(is_analog_device_init());
     print_avail_channels();
     return CQ_SUCCESS;
 }
 
 cq_status cq_print_channel(channel *ch) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(validate_channel(ch));
-    HANDLE_CQA_ERR(validate_channel_params(ch));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(validate_channel(ch));
+    HANDLE_CQ_ERROR(validate_channel_params(ch));
     print_channel(ch);
     return CQ_SUCCESS;
 }
 
 cq_status cq_print_qpos(int qreg_id) {
-    HANDLE_CQA_ERR(is_analog_device_init());
-    HANDLE_CQA_ERR(validate_qreg_id(qreg_id));
-    HANDLE_CQA_ERR(print_qpos(qreg_id));
+    HANDLE_CQ_ERROR(is_analog_device_init());
+    HANDLE_CQ_ERROR(validate_qreg_id(qreg_id));
+    HANDLE_CQ_ERROR(print_qpos(qreg_id));
     return CQ_SUCCESS;
 }
 
 ptrdiff_t cq_duration_to_samples(double duration) {
-    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQ_ERROR(is_analog_device_init());
     if (duration < 0.0) return 0;
     return duration_to_samples(duration);
 }
 
 double cq_samples_to_duration(ptrdiff_t num_samples) {
-    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQ_ERROR(is_analog_device_init());
     if (num_samples < 0) return 0.0;
     return samples_to_duration(num_samples);
 }
-
-#undef HANDLE_CQA_ERR

--- a/src/device/analog/analog.c
+++ b/src/device/analog/analog.c
@@ -1,0 +1,453 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#include "analog.h"
+
+#include "analog_datatypes.h"
+#include "analog_device.h"
+#include "analog_qreg.h"
+#include "channel.h"
+#include "pulse.h"
+#include "waveforms.h"
+
+#include <stdio.h>
+
+//============================ VALIDATION =====================================
+#define HANDLE_CQA_ERR(x)                           \
+        {                                           \
+            if (x == CQ_ERROR)                      \
+            {                                       \
+                printf(" From: %s\n", __func__);    \
+                return CQ_ERROR;                    \
+            }                                       \
+        };
+
+static cq_status validate_num_qubits(int num_qubits) {
+    if (num_qubits <= 0 || num_qubits > __CQ_ANALOG_MAX_NUM_QUBITS__) {
+        printf("Error: Specified number of qubits out-of-bounds. "
+               "Should be in [1, %d] range, given %d.",
+               __CQ_ANALOG_MAX_NUM_QUBITS__,
+               num_qubits);
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_qubits_idx(int qidx) {
+    if (qidx < 0 || qidx >= __CQ_ANALOG_MAX_NUM_QUBITS__) {
+        printf("Error: Specified qubit idx out-of-bounds. "
+               "Should be in [0, %d] range, given %d.",
+               __CQ_ANALOG_MAX_NUM_QUBITS__ - 1,
+               qidx);
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_qreg_id(int qreg_id) {
+    if (qreg_id < 0 ||
+        qreg_id >= __CQ_ANALOG_MAX_NUM_QUREGS__) {
+        printf("Error: Attempting to access qreg with "
+               "out-of-bounds index: %d. "
+               "Should be in [0, %d] range.",
+               qreg_id,
+               __CQ_ANALOG_MAX_NUM_QUREGS__ - 1);
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_channel_type(int type, addressing target) {
+    if (type > 4) {
+        printf("Error: Provided channel type is undefined "
+               "(should be in [0, 4] range, given %d).", type);
+        return CQ_ERROR;
+    }
+    if (target == GLOBAL) {
+        if (type == RYDBERG_LOCAL || type == RAMAN_LOCAL) {
+            printf("Error: Expected channel addressing is GLOBAL but LOCAL was given.");
+            return CQ_ERROR;
+        }
+    } else if(target == LOCAL) {
+        if (type == RYDBERG_GLOBAL || type == DMM_GLOBAL) {
+            printf("Error: Expected channel addressing is LOCAL but GLOBAL was given.");
+            return CQ_ERROR;
+        }
+    }
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_channel(const channel *ch) {
+    if (!ch) {
+        printf("Error: Channel is nullptr.");
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_channel_params(const channel *ch) {
+    if (!ch->params) {
+        printf("Error: Channel params is nullptr.");
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_channels(channel **ch, int num_channels) {
+    if (!ch) {
+        printf("Error: Array of channels is null.");
+        return CQ_ERROR;
+    }
+
+    if (num_channels < 1) {
+        printf("Error: Number of passed channels is < 1.");
+        return CQ_ERROR;
+    }
+
+    for (ptrdiff_t i = 0; i < num_channels; ++i) {
+        if (!ch[i] || !ch[i]->params) {
+            printf("Error: One of the passed channels is nullptr.");
+            return CQ_ERROR;
+        }
+    }
+
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_pulse(const pulse *pulse) {
+    if (!pulse) {
+        printf("Error: Pulse is nullptr.");
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_samples(double *samples) {
+    if (!samples) {
+        printf("Error: Samples are nullptr.");
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_num_samples(int num_samples) {
+    if (num_samples < 1) {
+        printf("Error: Specified num_samples < 1.");
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_values(double *values) {
+    if (!values) {
+        printf("Error: Values for custom waveform are nullptr.");
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_result(int *result) {
+    if (!result) {
+        printf("Error: Result is nullptr.");
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_num_shots(int shots) {
+    if (shots < 1) {
+        printf("Error: Number of shots is < 1.");
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_composite_wf(double *samples, double **waveforms,
+                       ptrdiff_t *num_samples, int num_waveforms,
+                       ptrdiff_t *total_num_samples) {
+    if (!samples) {
+        printf("Error: Samples for composite waveform are nullptr.");
+        return CQ_ERROR;
+    }
+    if (!waveforms) {
+        printf("Error: Waveforms for composite waveform are nullptr.");
+        return CQ_ERROR;
+    }
+    if (!num_samples) {
+        printf("Error: Array of num_samples for composite waveform are nullptr.");
+        return CQ_ERROR;
+    }
+    for (int i = 0; i < num_waveforms; ++i) {
+        if (num_samples[i] < 0) {
+            printf("Error: num_samples[%d] is negative.", i);
+            return CQ_ERROR;
+        }
+    }
+    if (num_waveforms < 1) {
+        printf("Error: Passed number of waveforms < 1.");
+        return CQ_ERROR;
+    }
+    if (!total_num_samples) {
+        printf("Error: Out-variable total_num_samples is nullptr.");
+        return CQ_ERROR;
+    }
+
+    return CQ_SUCCESS;
+}
+
+static cq_status prevalidate_duration(double duration) {
+    if (duration < __CQ_ANALOG_EPSILON__) {
+        printf("Error: Duration should be > 0.0.");
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_freq(double freq) {
+    if (freq < 0.0) {
+        printf("Error: Frequency should be > 0.0.");
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+//========================== ANALOG DEVICE OPS ================================
+cq_status cq_enable_analog_mode(device_mode mode) {
+    return enable_analog_mode(mode);
+}
+
+cq_status cq_enable_analog_qreg(int qreg_id, int num_qubits) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(validate_qreg_id(qreg_id));
+    HANDLE_CQA_ERR(validate_num_qubits(num_qubits));
+    return enable_analog_qreg(qreg_id, num_qubits);
+}
+
+cq_status cq_disable_analog_qreg(int qreg_id) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(validate_qreg_id(qreg_id));
+    return disable_analog_qreg(qreg_id);
+}
+
+cq_status cq_get_global_channel(channel *ch, int type, int qreg_id) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(validate_channel(ch));
+    HANDLE_CQA_ERR(validate_channel_type(type, GLOBAL));
+    HANDLE_CQA_ERR(validate_qreg_id(qreg_id));
+    return get_global_channel(ch, type, qreg_id);
+}
+
+cq_status cq_get_local_channel(channel *ch, int type, int target, int qreg_id) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(validate_channel(ch));
+    HANDLE_CQA_ERR(validate_channel_type(type, LOCAL));
+    HANDLE_CQA_ERR(validate_qubits_idx(target));
+    HANDLE_CQA_ERR(validate_qreg_id(qreg_id));
+    return get_local_channel(ch, type, target, qreg_id);
+}
+
+cq_status cq_update_qreg_pos(const qpos *new_positions, int num_qubits, int qreg_id) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    if (!new_positions) {
+        printf("Error: Passed nullptr positions. From: %s\n", __func__);
+        return CQ_ERROR;
+    }
+
+    HANDLE_CQA_ERR(validate_num_qubits(num_qubits));
+    HANDLE_CQA_ERR(validate_qreg_id(qreg_id));
+    return update_qreg_pos(new_positions, num_qubits, qreg_id);
+}
+
+//================================ PULSE ======================================
+cq_status cq_init_pulse(pulse *pulse, double duration) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(validate_pulse(pulse));
+    return init_pulse(pulse, duration);
+}
+
+cq_status cq_play(channel *ch, pulse *pulse) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(validate_channel(ch));
+    HANDLE_CQA_ERR(validate_channel_params(ch));
+    HANDLE_CQA_ERR(validate_pulse(pulse));
+    return play(ch, pulse);
+}
+
+cq_status cq_capture(channel *ch, pulse *pulse, int *result, int shots) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(validate_channel(ch));
+    // can capture only with channels that have valid target
+    HANDLE_CQA_ERR(validate_channel_type(ch->type, LOCAL));
+    HANDLE_CQA_ERR(validate_channel_params(ch));
+    HANDLE_CQA_ERR(validate_pulse(pulse));
+    HANDLE_CQA_ERR(validate_result(result));
+    HANDLE_CQA_ERR(validate_num_shots(shots));
+    return capture(ch, pulse, result, shots);
+}
+
+cq_status cq_delay(channel *ch, double dt) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(validate_channel(ch));
+    HANDLE_CQA_ERR(validate_channel_params(ch));
+    return delay(ch, dt);
+}
+
+cq_status cq_barrier(channel **ch, int num_channels) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(validate_channels(ch, num_channels));
+    return barrier(ch, num_channels);
+}
+
+//=============================== WAVEFORMS ===================================
+
+cq_status cq_gaussian_wf(double *samples, double duration, double amp, double sigma) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(prevalidate_duration(duration));
+    HANDLE_CQA_ERR(validate_samples(samples));
+    return gaussian_wf(samples, duration, amp, sigma);
+}
+
+cq_status cq_gaussian_sqr_wf(double *samples, double duration, double amp,
+                          double sigma, double width) {
+    printf("Error: Not implemented!\n");
+    return CQ_ERROR;
+
+    HANDLE_CQA_ERR(validate_samples(samples));
+    if (width > duration) {
+        printf("Error: Specified width would produce negative risefall. "
+               "Width must be < duration. From: %s\n", __func__);
+        return CQ_ERROR;
+    }
+
+    return gaussian_sqr_wf(samples, duration, amp,
+                          sigma, width);
+}
+
+cq_status cq_interpolated_wf(double *samples, double duration,
+                          double *points, int num_points) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(prevalidate_duration(duration));
+    HANDLE_CQA_ERR(validate_samples(samples));
+    if (!points) {
+        printf("Error: Passed nullptr instead of array of points. "
+               "From: %s\n", __func__);
+        return CQ_ERROR;
+    }
+
+    if (num_points < 2) {
+        printf("Error: Specified number of points is < 2. "
+               "Must pass at least 2 points. From: %s\n", __func__);
+        return CQ_ERROR;
+    }
+
+    return interpolated_wf(samples, duration,
+                          points, num_points);
+}
+
+cq_status cq_sech_wf(double *samples, double duration, double amp, double sigma) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(prevalidate_duration(duration));
+    HANDLE_CQA_ERR(validate_samples(samples));
+    return sech_wf(samples, duration, amp, sigma);
+}
+
+cq_status cq_sin_wf(double *samples, double duration, double amp,
+                 double freq, double phase) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(prevalidate_duration(duration));
+    HANDLE_CQA_ERR(validate_samples(samples));
+    HANDLE_CQA_ERR(validate_freq(freq));
+    return sin_wf(samples, duration, amp,
+                 freq, phase);
+}
+
+cq_status cq_cos_wf(double *samples, double duration, double amp,
+                 double freq, double phase) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(prevalidate_duration(duration));
+    HANDLE_CQA_ERR(validate_samples(samples));
+    HANDLE_CQA_ERR(validate_freq(freq));
+    return cos_wf(samples, duration, amp,
+                 freq, phase);
+}
+
+cq_status cq_blackman_wf(double *samples, double duration, double amp) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(prevalidate_duration(duration));
+    HANDLE_CQA_ERR(validate_samples(samples));
+    return blackman_wf(samples, duration, amp);
+}
+
+cq_status cq_saw_wf(double *samples, double duration, double amp,
+                 double freq, double phase) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(prevalidate_duration(duration));
+    HANDLE_CQA_ERR(validate_samples(samples));
+    HANDLE_CQA_ERR(validate_freq(freq));
+    return saw_wf(samples, duration, amp,
+                 freq, phase);
+}
+
+cq_status cq_custom_wf(double *samples, double *values, int num_samples) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(validate_samples(samples));
+    HANDLE_CQA_ERR(validate_values(values));
+    HANDLE_CQA_ERR(validate_num_samples(num_samples));
+    return custom_wf(samples, values, num_samples);
+}
+
+cq_status cq_composite_wf(double *samples, double **waveforms,
+                       ptrdiff_t *num_samples, int num_waveforms,
+                       ptrdiff_t *total_num_samples) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(validate_composite_wf(samples, waveforms, num_samples,
+                                         num_waveforms, total_num_samples));
+    return composite_wf(samples, waveforms,
+                       num_samples, num_waveforms,
+                       total_num_samples);
+}
+
+cq_status cq_print_analog_device(void) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    print_analog_device();
+    return CQ_SUCCESS;
+}
+cq_status cq_print_avail_channels(void) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    print_avail_channels();
+    return CQ_SUCCESS;
+}
+
+cq_status cq_print_channel(channel *ch) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(validate_channel(ch));
+    HANDLE_CQA_ERR(validate_channel_params(ch));
+    print_channel(ch);
+    return CQ_SUCCESS;
+}
+
+cq_status cq_print_qpos(int qreg_id) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    HANDLE_CQA_ERR(validate_qreg_id(qreg_id));
+    HANDLE_CQA_ERR(print_qpos(qreg_id));
+    return CQ_SUCCESS;
+}
+
+ptrdiff_t cq_duration_to_samples(double duration) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    if (duration < 0.0) return 0;
+    return duration_to_samples(duration);
+}
+
+double cq_samples_to_duration(ptrdiff_t num_samples) {
+    HANDLE_CQA_ERR(is_analog_device_init());
+    if (num_samples < 0) return 0.0;
+    return samples_to_duration(num_samples);
+}
+
+#undef HANDLE_CQA_ERR

--- a/src/device/analog/analog_datatypes.h
+++ b/src/device/analog/analog_datatypes.h
@@ -1,0 +1,107 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#ifndef CQ_ANALOG_DATATYPES_H
+#define CQ_ANALOG_DATATYPES_H
+
+#include "analog.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+// ---------- structs ---------------------------------------------------------
+typedef struct term_range {
+    ptrdiff_t start;
+    ptrdiff_t end;
+} term_range;
+
+typedef enum channel_type {
+    RYDBERG_GLOBAL = 0,
+    RYDBERG_LOCAL = 1,
+    RAMAN_LOCAL = 2,
+    DMM_GLOBAL = 3,
+    MW_GLOBAL = 4
+} channel_type;
+
+typedef enum addressing {
+    LOCAL = 0,
+    GLOBAL = 1
+} addressing;
+
+typedef struct channel_params {
+    double max_freq;            // rad/microsec
+    double max_detuning;        // rad/microsec
+    double min_amp;             // rad/microsec
+    double min_retarget_dt;     // ns
+    double retarget_delay;      // ns
+    double sample_rate;         // GHz
+    double min_pulse_duration;  // ns
+    int max_targets;            // -1 -> no max i.e. global
+    addressing addressing;
+    int qreg_id;               // on which qreg the channel operates
+} channel_params;
+
+
+#define __CQ_ANALOG_MAX_NUM_QUBITS__ 59
+// NOTE: PAULI_STR_LEN == MAX_NUM_QUBITS
+#define __CQ_ANALOG_MAX_PAULI_STR_LEN__ __CQ_ANALOG_MAX_NUM_QUBITS__
+typedef struct ham_term {
+    char paulis[__CQ_ANALOG_MAX_PAULI_STR_LEN__];
+    int indices[__CQ_ANALOG_MAX_PAULI_STR_LEN__];
+    ptrdiff_t num_paulis;
+
+    int var_idx;
+    double sign;
+} ham_term;
+
+#define __CQ_ANALOG_MAX_NUM_HAM_TERMS__ 8192
+typedef struct cq_hamiltonian {
+    double real[__CQ_ANALOG_MAX_NUM_HAM_TERMS__];
+    double imag[__CQ_ANALOG_MAX_NUM_HAM_TERMS__];
+    ham_term terms[__CQ_ANALOG_MAX_NUM_HAM_TERMS__];
+    ptrdiff_t num_terms;
+
+} cq_hamiltonian;
+
+#define __CQ_ANALOG_MAX_NUM_CHANNELS__ __CQ_ANALOG_MAX_NUM_QUBITS__ + 1
+typedef struct analog_qreg {
+    int id;
+    bool in_use;
+    int num_qubits;
+    qpos qubit_pos[__CQ_ANALOG_MAX_NUM_QUBITS__];
+    term_range sys_terms_range;
+
+    channel channels[__CQ_ANALOG_MAX_NUM_CHANNELS__];
+    ptrdiff_t num_channels;
+    term_range channels_ranges[__CQ_ANALOG_MAX_NUM_CHANNELS__];
+
+    channel_params channel_params[4];
+} analog_qreg;
+
+#define __CQ_ANALOG_MAX_NUM_QUREGS__ 64
+typedef struct analog_device {
+    double sample_rate;                 // GHz i.e 1/ns
+    double min_pulse_duration;          // ns
+    double max_pulse_duration;          // ns
+    double ising_coefficient;
+    double xy_coefficient;
+    double max_atom_dist_from_origin;   // micrometers
+    double min_dist_between_atom;       // micrometers
+    int max_num_shots;
+    bool is_initialized;
+    device_mode mode;
+
+    analog_qreg qregs[__CQ_ANALOG_MAX_NUM_QUREGS__];
+    cq_hamiltonian hamiltonians[__CQ_ANALOG_MAX_NUM_QUREGS__];
+
+} analog_device;
+
+#define __CQ_ANALOG_EPSILON__ 0.0000000001
+
+#endif // CQ_ANALOG_DATATYPES_H

--- a/src/device/analog/analog_device.c
+++ b/src/device/analog/analog_device.c
@@ -1,0 +1,268 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#include "analog_device.h"
+
+#include "analog_qreg.h"
+#include "channel.h"
+#include "hamil.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+static analog_device device = {0};
+
+static cq_status validate_qreg_is_init(analog_qreg *qreg) {
+    if (!qreg) return CQ_ERROR;
+    if (!qreg->in_use) {
+        printf("Error: The qreg with index: %d was not initialised in analog mode.\n", qreg->id);
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+static cq_status setup_device_params(device_mode mode) {
+    // Pulser settings based on Pasqal device
+    // used to reproduce experiments
+    device.sample_rate = 0.25;
+    device.min_pulse_duration = 16.0;
+    device.max_pulse_duration = 60000.0;
+    //device.ising_coefficient = 865723.02;
+    device.ising_coefficient = 5420158.53;
+    device.xy_coefficient = 3700.0;
+    device.max_atom_dist_from_origin = 50.0;
+    device.min_dist_between_atom = 4.0;
+    device.max_num_shots = 2000;
+    device.mode = mode;
+
+    return CQ_SUCCESS;
+}
+
+cq_status enable_analog_mode(device_mode mode) {
+    if (device.is_initialized) {
+        printf("Error: Attempting to re-initialize analog mode.\n");
+        return CQ_ERROR;
+    }
+    setup_device_params(mode);
+
+    device.is_initialized = true;
+    return CQ_SUCCESS;
+}
+
+cq_status enable_analog_qreg(int qreg_id, int num_qubits) {
+    assert(qreg_id > -1 && qreg_id < __CQ_ANALOG_MAX_NUM_QUREGS__);
+    assert(num_qubits > 0 && num_qubits <= __CQ_ANALOG_MAX_NUM_QUBITS__);
+
+    if (!device.is_initialized) {
+        printf("Error: Attempting to run analog operation without "
+               "analog mode on. From: %s\n", __func__);
+        return CQ_ERROR;
+    }
+
+    analog_qreg *qreg = &device.qregs[qreg_id];
+    if (qreg->in_use) {
+        printf("Error: Attempting to use qreg that is already in use.\n");
+        return CQ_ERROR;
+    }
+
+    cq_hamiltonian *hamiltonian = &device.hamiltonians[qreg_id];
+    init_qreg(qreg, qreg_id, num_qubits, hamiltonian);
+    return CQ_SUCCESS;
+}
+
+cq_status disable_analog_qreg(int qreg_id) {
+    assert(qreg_id > -1 && qreg_id < __CQ_ANALOG_MAX_NUM_QUREGS__);
+
+    if (!device.is_initialized) {
+        printf("Error: Attempting to run analog operation without "
+               "analog mode on. From: %s\n", __func__);
+        return CQ_ERROR;
+    }
+
+    analog_qreg *qreg = &device.qregs[qreg_id];
+    if (!qreg->in_use) {
+        printf("Error: Attempting to disable analog mode on qreg which was already disabled.\n");
+        return CQ_ERROR;
+    }
+    reset_qreg(qreg);
+
+    cq_hamiltonian *hamiltonian = &device.hamiltonians[qreg_id];
+    reset_hamiltonian(hamiltonian);
+
+    return CQ_SUCCESS;
+}
+
+cq_status get_global_channel(channel *ch, int type, int qreg_id) {
+    assert(ch != NULL);
+    assert(qreg_id > -1 && qreg_id < __CQ_ANALOG_MAX_NUM_QUREGS__);
+    //if (validate_channel_type(type, LOCAL) == CQ_ERROR) return CQ_ERROR;
+
+    if (!device.is_initialized) {
+        printf("Error: Attempting to run analog operation without "
+               "analog mode on. From: %s\n", __func__);
+        return CQ_ERROR;
+    }
+
+    analog_qreg *qreg = &device.qregs[qreg_id];
+    if (validate_qreg_is_init(qreg) == CQ_ERROR) {
+        printf("Error: Attempting to get channel to operate on a uninitialized qreg.\n");
+        return CQ_ERROR;
+    }
+
+    for (int i = 0; i < qreg->num_channels; ++i) {
+        if (qreg->channels[i].type == type) {
+            return copy_channel(ch, &qreg->channels[i]);
+        }
+    }
+    printf("Error: Couldn't find the requested channel. Check your inputs.\n");
+    return CQ_ERROR;
+}
+
+cq_status get_local_channel(channel *ch, int type, int target, int qreg_id) {
+    assert(ch != NULL);
+    assert(qreg_id > -1 && qreg_id < __CQ_ANALOG_MAX_NUM_QUREGS__);
+    assert(target > -1 && qreg_id < __CQ_ANALOG_MAX_NUM_QUBITS__);
+    //if (validate_channel_type(type, LOCAL) == CQ_ERROR) return CQ_ERROR;
+    if (!device.is_initialized) {
+        printf("Error: Attempting to run analog operation without "
+               "analog mode on. From: %s\n", __func__);
+        return CQ_ERROR;
+    }
+
+    analog_qreg *qreg = &device.qregs[qreg_id];
+    if (validate_qreg_is_init(qreg) == CQ_ERROR) {
+        printf("Error: Attempting to get channel to operate on "
+               "a uninitialized qreg. From: %s\n", __func__);
+        return CQ_ERROR;
+    }
+
+    if (target >= qreg->num_qubits) {
+        printf("Error: Provided target (%d) is larger than number of qubits "
+               "in given register (qreg id: %d). From: %s\n",
+               target, qreg->num_qubits, __func__);
+        return CQ_ERROR;
+    }
+
+    for (int i = 0; i < qreg->num_channels; ++i) {
+        if (qreg->channels[i].type == type &&
+            qreg->channels[i].target == target) {
+            return copy_channel(ch, &qreg->channels[i]);
+        }
+    }
+    printf("Error: Couldn't find the requested channel. Check your inputs.\n");
+    return CQ_ERROR;
+}
+
+cq_status is_analog_device_init(void) {
+    if (!device.is_initialized) {
+        printf("Error: Attempting to run analog operation but "
+               "analog device was not initialised!\n");
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+cq_hamiltonian * get_hamiltonian(const analog_qreg *qreg) {
+    assert(device.is_initialized);
+    assert(qreg != NULL);
+    return &device.hamiltonians[qreg->id];
+}
+
+analog_qreg * get_qreg(int qreg_id) {
+    assert(device.is_initialized);
+    assert(qreg_id > -1 && qreg_id < __CQ_ANALOG_MAX_NUM_QUREGS__);
+    return &device.qregs[qreg_id];
+}
+
+double get_device_sample_rate(void) {
+    assert(device.is_initialized);
+    return device.sample_rate;
+}
+
+double get_device_min_pulse_duration(void) {
+    assert(device.is_initialized);
+    return device.min_pulse_duration;
+}
+
+double get_device_max_pulse_duration(void) {
+    assert(device.is_initialized);
+    return device.max_pulse_duration;
+}
+
+double get_device_ising_coeff(void) {
+    assert(device.is_initialized);
+    return device.ising_coefficient;
+}
+
+double get_device_xy_coeff(void) {
+    assert(device.is_initialized);
+    return device.xy_coefficient;
+}
+
+double get_device_min_atom_dist(void) {
+    assert(device.is_initialized);
+    return device.min_dist_between_atom;
+}
+
+int get_device_max_num_shots(void) {
+    assert(device.is_initialized);
+    return device.max_num_shots;
+}
+
+device_mode get_device_operating_mode(void) {
+    assert(device.is_initialized);
+    return device.mode;
+}
+
+ptrdiff_t duration_to_samples(double duration) {
+    return (ptrdiff_t)(device.sample_rate * duration);
+}
+
+double samples_to_duration(ptrdiff_t num_samples) {
+    return (double)num_samples / device.sample_rate;
+}
+
+static const char *get_mode_str(device_mode mode) {
+    switch (mode) {
+        case RYDBERG:
+            return "RYDBERG";
+        case XY:
+            return "XY";
+        default:
+            return "Unknown";
+    }
+}
+
+void print_analog_device(void) {
+    assert(device.is_initialized);
+    printf("==============================================================\n"
+        "Analog Device Specification:\n"
+           "Operating Modes: RYDBERG, XY\n"
+           "Selected mode: %s\n"
+           "Sample rate: %f\n"
+           "Min pulse duration: %f\n"
+           "Max pulse duration: %f\n"
+           "Max number of shots: %d\n"
+           "Ising coefficient: %f\n"
+           "\n-------- If RYDBERG or XY: --------\n"
+           "XY coefficient: %f\n"
+           "Min distance between atoms: %f\n"
+           "Max atom distance from origin: %f\n"
+           "==============================================================\n",
+            get_mode_str(device.mode),
+            device.sample_rate,
+            device.min_pulse_duration       ,
+            device.max_pulse_duration       ,
+            device.max_num_shots            ,
+            device.ising_coefficient        ,
+            device.xy_coefficient           ,
+            device.min_dist_between_atom    ,
+            device.max_atom_dist_from_origin
+    );
+}

--- a/src/device/analog/analog_device.h
+++ b/src/device/analog/analog_device.h
@@ -1,0 +1,39 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#ifndef CQ_ANALOG_DEVICE_H
+#define CQ_ANALOG_DEVICE_H
+
+#include "analog_datatypes.h"
+
+cq_status enable_analog_mode(device_mode mode);
+cq_status enable_analog_qreg(int qreg_id, int num_qubits);
+cq_status disable_analog_qreg(int qreg_id);
+cq_status get_global_channel(channel *ch, int type, int qreg_id);
+cq_status get_local_channel(channel *ch, int type, int target, int qreg_id);
+cq_status is_analog_device_init(void);
+
+cq_hamiltonian * get_hamiltonian(const analog_qreg *qreg);
+analog_qreg * get_qreg(int qreg_id);
+
+double get_device_sample_rate(void);
+double get_device_min_pulse_duration(void);
+double get_device_max_pulse_duration(void);
+double get_device_ising_coeff(void);
+double get_device_xy_coeff(void);
+double get_device_min_atom_dist(void);
+int get_device_max_num_shots(void);
+device_mode get_device_operating_mode(void);
+
+ptrdiff_t duration_to_samples(double duration);
+double samples_to_duration(ptrdiff_t num_samples);
+
+void print_analog_device(void);
+
+#endif // CQ_ANALOG_DEVICE_H

--- a/src/device/analog/analog_qreg.c
+++ b/src/device/analog/analog_qreg.c
@@ -1,0 +1,146 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#include "analog_qreg.h"
+
+#include "analog_device.h"
+#include "channel.h"
+#include "hamil.h"
+#include "simulator.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+cq_status init_qreg(analog_qreg *qreg, int qreg_id, int num_qubits, cq_hamiltonian *hamiltonian) {
+    assert(qreg != NULL);
+    assert(qreg_id > -1 && qreg_id < __CQ_ANALOG_MAX_NUM_QUREGS__);
+    assert(num_qubits > 0 && num_qubits <= __CQ_ANALOG_MAX_NUM_QUBITS__);
+    assert(hamiltonian != NULL);
+
+    qreg->in_use = true;
+    qreg->id = qreg_id;
+    qreg->num_qubits = num_qubits;
+
+    init_qubit_pos(qreg->qubit_pos, num_qubits);
+    setup_channel_params(qreg);
+    add_interaction_terms(qreg, hamiltonian);
+    add_driving_terms(qreg, hamiltonian);
+
+    init_simulator_qreg(qreg_id, num_qubits);
+
+    return CQ_SUCCESS;
+}
+
+cq_status init_qubit_pos(qpos *qubit_pos, int num_qubits) {
+    assert(qubit_pos != NULL);
+    assert(num_qubits > 0 && num_qubits <= __CQ_ANALOG_MAX_NUM_QUBITS__);
+
+    double min_dist = get_device_min_atom_dist() + 0.00001;
+    for (int i = 0; i < num_qubits; ++i) {
+        qubit_pos[i].x = i * min_dist;
+        qubit_pos[i].y = 0.0;
+        qubit_pos[i].z = 0.0;
+    }
+    return CQ_SUCCESS;
+}
+
+cq_status reset_qreg(analog_qreg *qreg) {
+    assert(qreg != NULL);
+    if (!qreg->in_use) {
+        printf("Error: Attempting to disable analog mode on qreg which was already disabled.\n");
+        return CQ_ERROR;
+    }
+
+    qreg->in_use = false;
+
+    qreg->num_qubits = 0;
+    qreg->sys_terms_range.start = 0;
+    qreg->sys_terms_range.end = 0;
+    qreg->num_channels = 0;
+
+    for (ptrdiff_t i = 0; i < __CQ_ANALOG_MAX_NUM_QUBITS__; ++i) {
+        qreg->qubit_pos[i].x = 0;
+        qreg->qubit_pos[i].y = 0;
+        qreg->qubit_pos[i].z = 0;
+    }
+
+    for (ptrdiff_t i = 0; i < __CQ_ANALOG_MAX_NUM_CHANNELS__; ++i) {
+        qreg->channels_ranges[i].start = 0;
+        qreg->channels_ranges[i].end = 0;
+
+        qreg->channels[i].id = 0;
+        qreg->channels[i].type = 0;
+        qreg->channels[i].target = 0;
+        qreg->channels[i].time = 0.0;
+        qreg->channels[i].params = NULL;
+    }
+
+    reset_simulator_qreg(qreg->id);
+    return CQ_SUCCESS;
+}
+
+cq_status update_qreg_pos(const qpos *positions, int num_qubits, int qreg_id) {
+    assert(positions != NULL);
+    assert(num_qubits > 0 && num_qubits < __CQ_ANALOG_MAX_NUM_QUBITS__);
+    assert(qreg_id > -1 && qreg_id < __CQ_ANALOG_MAX_NUM_QUREGS__);
+
+    analog_qreg *qreg = get_qreg(qreg_id);
+    assert(qreg != NULL);
+
+    if (!qreg->in_use) {
+        printf("Error: The qreg with index: %d was not initialised "
+               "in analog mode. From: %s\n",
+               qreg->id, __func__);
+        return CQ_ERROR;
+    }
+
+    if (num_qubits > qreg->num_qubits) {
+        printf("Error: The passed num_qubits (%d) is larger than the size "
+               "of register (%d). From: %s\n",
+               num_qubits, qreg->num_qubits, __func__);
+        return CQ_ERROR;
+    }
+
+    for (int i = 0; i < num_qubits; ++i) {
+        qreg->qubit_pos[i].x = positions[i].x;
+        qreg->qubit_pos[i].y = positions[i].y;
+        qreg->qubit_pos[i].z = positions[i].z;
+    }
+
+    if(update_sys_terms(qreg, get_hamiltonian(qreg)) == CQ_ERROR) return CQ_ERROR;
+    sync_simulator(get_hamiltonian(qreg), qreg_id);
+
+    return CQ_SUCCESS;
+}
+
+
+cq_status print_qpos(int qreg_id) {
+    assert(qreg_id > -1 && qreg_id < __CQ_ANALOG_MAX_NUM_QUREGS__);
+
+    analog_qreg *qreg = get_qreg(qreg_id);
+    assert(qreg != NULL);
+
+    if (!qreg->in_use) {
+        printf("Error: The qreg with index: %d was not initialised "
+               "in analog mode. From: %s\n",
+               qreg->id, __func__);
+        return CQ_ERROR;
+    }
+
+    printf("Qubit positions in qreg %d:\n", qreg_id);
+    for (int i = 0; i < qreg->num_qubits; ++i) {
+        printf("q%d: %f %f %f\n", i,
+            qreg->qubit_pos[i].x,
+            qreg->qubit_pos[i].y,
+            qreg->qubit_pos[i].z
+        );
+    }
+
+    return CQ_SUCCESS;
+}

--- a/src/device/analog/analog_qreg.h
+++ b/src/device/analog/analog_qreg.h
@@ -1,0 +1,24 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#ifndef CQ_ANALOG_QREG_H
+#define CQ_ANALOG_QREG_H
+
+#include "analog_datatypes.h"
+
+cq_status init_qreg(analog_qreg *qreg, int qreg_id,
+                    int num_qubits, cq_hamiltonian *hamiltonian);
+cq_status init_qubit_pos(qpos *qubit_pos, int num_qubits);
+cq_status reset_qreg(analog_qreg *qreg);
+
+cq_status update_qreg_pos(const qpos *new_positions, int num_qubits, int qreg_id);
+
+cq_status print_qpos(int qreg_id);
+
+#endif // CQ_ANALOG_QREG_H

--- a/src/device/analog/channel.c
+++ b/src/device/analog/channel.c
@@ -1,0 +1,196 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#include "channel.h"
+#include <assert.h>
+#include <stdio.h>
+
+static cq_status setup_rydberg_local_params(channel_params *params, int qreg_id) {
+    assert(params != NULL);
+
+    params->max_freq = 62.83;
+    params->max_detuning = 125.7;
+    params->min_amp = 0.0;
+    params->min_retarget_dt = 220.0;
+    params->retarget_delay = 0.0;
+    params->sample_rate = 0.25;
+    params->min_pulse_duration = 16;
+    params->max_targets = 1;
+    params->addressing = LOCAL;
+    params->qreg_id = qreg_id;
+
+    return CQ_SUCCESS;
+}
+
+static cq_status setup_rydberg_global_params(channel_params *params, int qreg_id) {
+    assert(params != NULL);
+
+    params->max_freq = 15.71;
+    params->max_detuning = 125.7;
+    params->min_amp = 0.0;
+    params->min_retarget_dt = 0.0;
+    params->retarget_delay = 0.0;
+    params->sample_rate = 0.25;
+    params->min_pulse_duration = 16;
+    params->max_targets = -1;
+    params->addressing = GLOBAL;
+    params->qreg_id = qreg_id;
+
+    return CQ_SUCCESS;
+}
+
+static cq_status setup_raman_local_params(channel_params *params, int qreg_id) {
+    assert(params != NULL);
+
+    params->max_freq = 62.83;
+    params->max_detuning = 125.7;
+    params->min_amp = 0.0;
+    params->min_retarget_dt = 220.0;
+    params->retarget_delay = 0.0;
+    params->sample_rate = 0.25;
+    params->min_pulse_duration = 16;
+    params->max_targets = 1;
+    params->addressing = LOCAL;
+    params->qreg_id = qreg_id;
+
+    return CQ_SUCCESS;
+}
+
+static cq_status setup_dmm_global_params(channel_params *params, int qreg_id) {
+    assert(params != NULL);
+
+    params->max_freq = 0.0;
+    params->max_detuning = 125.7;
+    params->min_amp = 0.0;
+    params->min_retarget_dt = 0.0;
+    params->retarget_delay = 0.0;
+    params->sample_rate = 0.25;
+    params->min_pulse_duration = 16;
+    params->max_targets = -1;
+    params->addressing = GLOBAL;
+    params->qreg_id = qreg_id;
+
+    return CQ_SUCCESS;
+}
+
+cq_status setup_channel_params(analog_qreg *qreg) {
+    assert(qreg != NULL);
+
+    int qreg_id = qreg->id;
+    setup_rydberg_global_params(&qreg->channel_params[RYDBERG_GLOBAL], qreg_id);
+    setup_rydberg_local_params(&qreg->channel_params[RYDBERG_LOCAL], qreg_id);
+    setup_raman_local_params(&qreg->channel_params[RAMAN_LOCAL], qreg_id);
+    setup_dmm_global_params(&qreg->channel_params[DMM_GLOBAL], qreg_id);
+    return CQ_SUCCESS;
+}
+
+cq_status copy_channel(channel *dest, const channel *src) {
+    assert(dest != NULL);
+    assert(src != NULL);
+    assert(src->params != NULL);
+    assert(src->id > -1);
+    assert(src->target > -2);
+    assert(src->target < __CQ_ANALOG_MAX_NUM_QUBITS__);
+    assert(src->time > -__CQ_ANALOG_EPSILON__);
+
+    dest->id = src->id;
+    dest->type = src->type;
+    dest->target = src->target;
+    dest->params = src->params;
+    dest->time = src->time;
+
+    return CQ_SUCCESS;
+}
+
+void print_avail_channels(void) {
+    printf("==============================================================\n"
+           "Available Channels:\n"
+           "----- RYDBERG_GLOBAL:     \n"
+            "\tmax_freq = 15.71       \n"
+            "\tmax_detuning = 125.7   \n"
+            "\tmin_amp = 0.0          \n"
+            "\tmin_retarget_dt = 0.0  \n"
+            "\tretarget_delay = 0.0   \n"
+            "\tsample_rate = 0.25     \n"
+            "\tmin_pulse_duration = 16\n"
+            "\tmax_targets = -1       \n"
+            "\taddressing = GLOBAL    \n\n"
+
+           "----- RYDBERG_LOCAL:      \n"
+            "\tmax_freq = 62.83       \n"
+            "\tmax_detuning = 125.7   \n"
+            "\tmin_amp = 0.0          \n"
+            "\tmin_retarget_dt = 220.0  \n"
+            "\tretarget_delay = 0.0   \n"
+            "\tsample_rate = 0.25     \n"
+            "\tmin_pulse_duration = 16\n"
+            "\tmax_targets = 1       \n"
+            "\taddressing = LOCAL    \n"
+            "==============================================================\n"
+    );
+}
+
+static const char *get_channel_type_str(channel_type type) {
+    switch (type) {
+        case RYDBERG_LOCAL:
+            return "RYDBERG_LOCAL";
+        case RYDBERG_GLOBAL:
+            return "RYDBERG_GLOBAL";
+        default:
+            return "Unknown";
+    }
+}
+
+static const char *get_addressing_str(addressing addressing) {
+    switch (addressing) {
+        case LOCAL:
+            return "LOCAL";
+        case GLOBAL:
+            return "GLOBAL";
+        default:
+            return "Unknown";
+    }
+}
+
+void print_channel(channel *ch) {
+    assert(ch != NULL);
+    channel_params *params = (channel_params *)ch->params;
+    assert(params != NULL);
+    printf(
+       "----- channel:      \n"
+            "\tid: %d\n"
+            "\ttype: %s\n"
+            "\ttarget: %d\n"
+            "\ttime: %f\n"
+            "\tmax_freq = %f       \n"
+            "\tmax_detuning = %f   \n"
+            "\tmin_amp = %f          \n"
+            "\tmin_retarget_dt = %f  \n"
+            "\tretarget_delay = %f   \n"
+            "\tsample_rate = %f    \n"
+            "\tmin_pulse_duration = %f\n"
+            "\tmax_targets = %d       \n"
+            "\taddressing = %s    \n",
+            ch->id,
+            get_channel_type_str(ch->type),
+            ch->target,
+            ch->time,
+            params->max_freq,
+            params->max_detuning,
+            params->min_amp,
+            params->min_retarget_dt,
+            params->retarget_delay,
+            params->sample_rate,
+            params->min_pulse_duration,
+            params->max_targets,
+            get_addressing_str(params->addressing)
+    );
+}
+
+

--- a/src/device/analog/channel.h
+++ b/src/device/analog/channel.h
@@ -1,0 +1,20 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#ifndef CQ_ANALOG_CHANNEL_H
+#define CQ_ANALOG_CHANNEL_H
+
+#include "analog_datatypes.h"
+
+cq_status setup_channel_params(analog_qreg *qreg);
+cq_status copy_channel(channel *dest, const channel *src);
+void print_avail_channels(void);
+void print_channel(channel *ch);
+
+#endif //CQ_ANALOG_CHANNEL_H

--- a/src/device/analog/hamil.c
+++ b/src/device/analog/hamil.c
@@ -1,0 +1,443 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#include "hamil.h"
+
+#include "analog_device.h"
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+
+term_modifier term_modifiers[TERM_MODIFIER_COUNT] = {
+    &rabi_freq_cos_modifier,
+    &rabi_freq_sin_modifier,
+    &detuning_modifier
+};
+
+static cq_status add_pauli_term(
+    cq_hamiltonian *hamiltonian, char pauli,
+    int target, int var_idx, double sign) {
+
+    assert(hamiltonian != NULL);
+    //assert(hamiltonian->num_terms < __CQ_ANALOG_MAX_NUM_HAM_TERMS__);
+    assert(pauli == 'I' || pauli == 'X' || pauli == 'Y' || pauli == 'Z' );
+    assert(target > -1 && target < __CQ_ANALOG_MAX_NUM_QUBITS__);
+    assert(var_idx > -1 && var_idx < TERM_MODIFIER_COUNT);
+    assert(sign - 1.0 < __CQ_ANALOG_EPSILON__ || sign + 1.0 < __CQ_ANALOG_EPSILON__);
+
+    if (hamiltonian->num_terms >= __CQ_ANALOG_MAX_NUM_HAM_TERMS__) {
+        printf("Error: Number of terms in hamiltonian surpasses maximum.\n");
+        return CQ_ERROR;
+    }
+
+    ptrdiff_t i = hamiltonian->num_terms;
+    hamiltonian->terms[i].paulis[0] = pauli;
+    hamiltonian->terms[i].indices[0] = target;
+    hamiltonian->terms[i].num_paulis = 1;
+    hamiltonian->terms[i].var_idx = var_idx;
+    hamiltonian->terms[i].sign = sign;
+    hamiltonian->real[i] = 0.0;
+    hamiltonian->imag[i] = 0.0;
+    hamiltonian->num_terms++;
+
+    return CQ_SUCCESS;
+}
+
+static double qubit_dist(const qpos *a, const qpos *b) {
+    assert(a != NULL);
+    assert(b != NULL);
+
+    double dist = 0.0;
+    double dx = a->x - b->x;
+    double dy = a->y - b->y;
+    double dz = a->z - b->z;
+    dist = dx * dx + dy * dy + dz * dz;
+
+    return sqrt(dist);
+}
+
+
+
+static cq_status ising_interaction(const qpos *q0, const qpos *q1, double *result) {
+    assert(q0 != NULL);
+    assert(q1 != NULL);
+
+    double C = get_device_ising_coeff();
+    double dist6 = qubit_dist(q0, q1);
+    if (dist6 < get_device_min_atom_dist()) {
+        printf("Error: The distance between atoms is too small. "
+               "Minimal distance between atoms is %f, given %f\n"
+               "Setting interaction strength to 0.0!",
+               get_device_min_atom_dist(), dist6);
+        *result = 0.0;
+        return CQ_ERROR;
+    }
+    dist6 = dist6 * dist6 * dist6 * dist6 * dist6 * dist6;
+    *result = (C / dist6) * 0.25;
+    return CQ_SUCCESS;
+}
+
+static cq_status xy_interaction(const qpos *q0, const qpos *q1, double *result) {
+    assert(q0 != NULL);
+    assert(q1 != NULL);
+
+    double C3 = get_device_xy_coeff();
+    double dist3 = qubit_dist(q0, q1);
+    if (dist3 < get_device_min_atom_dist()) {
+        printf("Error: The distance between atoms is too small. "
+               "Minimal distance between atoms is %f, given %f\n"
+               "Returning interaction strength = 0.0!",
+               get_device_min_atom_dist(), dist3);
+        *result = 0.0;
+        return CQ_ERROR;
+    }
+    dist3 = dist3 * dist3 * dist3;
+    *result = (C3 / dist3);
+    return CQ_SUCCESS;
+}
+
+static cq_status interaction(const qpos *q0, const qpos *q1, double *result) {
+    assert(q0 != NULL);
+    assert(q1 != NULL);
+
+    switch(get_device_operating_mode()) {
+        case RYDBERG:
+            return ising_interaction(q0, q1, result);
+        case XY:
+            return xy_interaction(q0, q1, result);
+        default:
+            return CQ_ERROR;
+    }
+}
+
+cq_status add_rydberg_local_term(int target, cq_hamiltonian *hamiltonian) {
+    assert(target > -1 && target < __CQ_ANALOG_MAX_NUM_QUBITS__);
+    assert(hamiltonian != NULL);
+
+    double sign = 1.0;
+    // Adding (w(t)cos(p(t))X + w(t)sin(p(t))Y - d(t)(1 - Z)) / 2
+    if (add_pauli_term(hamiltonian,
+                        'X', target,
+                        TERM_MODIFIER_RABI_COS,
+                        sign) != CQ_SUCCESS) return CQ_ERROR;
+
+    if (add_pauli_term(hamiltonian,
+                        'Y', target,
+                        TERM_MODIFIER_RABI_SIN,
+                        sign) != CQ_SUCCESS) return CQ_ERROR;
+
+    if (add_pauli_term(hamiltonian,
+                        'I', target,
+                        TERM_MODIFIER_DETUNING,
+                        -sign) != CQ_SUCCESS) return CQ_ERROR;
+
+    if (add_pauli_term(hamiltonian,
+                       'Z', target,
+                       TERM_MODIFIER_DETUNING,
+                       sign) != CQ_SUCCESS) return CQ_ERROR;
+
+    return CQ_SUCCESS;
+}
+
+cq_status add_rydberg_global_term(analog_qreg *qreg, cq_hamiltonian *hamiltonian) {
+    assert(qreg != NULL);
+    assert(qreg->in_use);
+    assert(qreg->num_qubits < __CQ_ANALOG_MAX_NUM_CHANNELS__);
+    assert(hamiltonian != NULL);
+
+    channel global_ch = {0};
+    global_ch.id = (int)(qreg->num_channels);
+    global_ch.type = RYDBERG_GLOBAL;
+    global_ch.target = -1;
+    global_ch.params = (void *)&qreg->channel_params[RYDBERG_GLOBAL];
+
+    qreg->channels_ranges[global_ch.id].start = hamiltonian->num_terms;
+    for (int i = 0; i < qreg->num_qubits; ++i) {
+        channel local_ch = {0};
+        local_ch.id = (int)(qreg->num_channels + 1);
+        local_ch.type = RYDBERG_LOCAL;
+        local_ch.target = i;
+        local_ch.params = (void *)&qreg->channel_params[RYDBERG_LOCAL];
+
+        qreg->channels_ranges[local_ch.id].start = hamiltonian->num_terms;
+        add_rydberg_local_term(i, hamiltonian);
+        qreg->channels_ranges[local_ch.id].end = hamiltonian->num_terms;
+
+        qreg->channels[local_ch.id] = local_ch;
+        qreg->num_channels++;
+    }
+    qreg->channels_ranges[global_ch.id].end = hamiltonian->num_terms;
+    qreg->channels[global_ch.id] = global_ch;
+    qreg->num_channels++;
+
+    return CQ_SUCCESS;
+}
+
+cq_status add_raman_local_term(int target, cq_hamiltonian *hamiltonian) {
+    // for raman, interaction is the same as for rydberg
+    // okay - it actually doesn't matter
+    // from my perspecitve raman and rydberg are the same - i dont care about
+    // the actual atom states
+    assert(target > -1 && target < __CQ_ANALOG_MAX_NUM_QUBITS__);
+    assert(hamiltonian != NULL);
+
+    double sign = 1.0;
+    // Adding (w(t)cos(p(t))X + w(t)sin(p(t))Y - d(t)(1 - Z)) / 2
+    if (add_pauli_term(hamiltonian,
+                        'X', target,
+                        TERM_MODIFIER_RABI_COS,
+                        sign) != CQ_SUCCESS) return CQ_ERROR;
+
+    if (add_pauli_term(hamiltonian,
+                        'Y', target,
+                        TERM_MODIFIER_RABI_SIN,
+                        sign) != CQ_SUCCESS) return CQ_ERROR;
+
+    if (add_pauli_term(hamiltonian,
+                        'I', target,
+                        TERM_MODIFIER_DETUNING,
+                        -sign) != CQ_SUCCESS) return CQ_ERROR;
+
+    if (add_pauli_term(hamiltonian,
+                       'Z', target,
+                       TERM_MODIFIER_DETUNING,
+                       sign) != CQ_SUCCESS) return CQ_ERROR;
+
+    return CQ_SUCCESS;
+}
+
+cq_status add_driving_terms(analog_qreg *qreg, cq_hamiltonian *hamiltonian) {
+    assert(qreg != NULL);
+    assert(qreg->in_use);
+    assert(qreg->num_qubits < __CQ_ANALOG_MAX_NUM_CHANNELS__);
+    assert(hamiltonian != NULL);
+
+    // actually in NA the driving hamiltonian is the same
+    // for rydberg, raman and even microwave channels (e.g. Pasqal)
+    // The only difference is in the physical qubit basis --
+    // however from the pov of simulation this does not matter
+    add_rydberg_global_term(qreg, hamiltonian);
+
+    // TODO: possibly driving for SC system (e.g. DWave)
+
+    return CQ_SUCCESS;
+}
+
+static void print_hamil(cq_hamiltonian *hamiltonian) {
+    printf("hamiltonian with %ld terms:\n", hamiltonian->num_terms);
+    for (ptrdiff_t i = 0; i < hamiltonian->num_terms; ++i) {
+        printf("%lf ", hamiltonian->real[i]);
+        for (ptrdiff_t j = 0; j < hamiltonian->terms[i].num_paulis; ++j) {
+            printf("%c", hamiltonian->terms[i].paulis[j]);
+        }
+        printf("\n");
+    }
+}
+
+static cq_status add_two_pauli_term(
+    cq_hamiltonian *hamiltonian, char pauli_i, char pauli_j,
+    int i, int j, double interaction_str) {
+
+    assert(hamiltonian != NULL);
+    assert(hamiltonian->num_terms < __CQ_ANALOG_MAX_NUM_HAM_TERMS__);
+    assert(pauli_i == 'I' || pauli_i == 'X' || pauli_i == 'Y' || pauli_i == 'Z' );
+    assert(pauli_j == 'I' || pauli_j == 'X' || pauli_j == 'Y' || pauli_j == 'Z' );
+    assert(i > -1 && i < __CQ_ANALOG_MAX_NUM_QUBITS__);
+    assert(j > -1 && j < __CQ_ANALOG_MAX_NUM_QUBITS__);
+
+    ptrdiff_t term_idx = hamiltonian->num_terms;
+    hamiltonian->terms[term_idx].paulis[0] = pauli_i;
+    hamiltonian->terms[term_idx].indices[0] = i;
+    hamiltonian->terms[term_idx].paulis[1] = pauli_j;
+    hamiltonian->terms[term_idx].indices[1] = j;
+    hamiltonian->terms[term_idx].num_paulis = 2;
+    hamiltonian->real[term_idx] = interaction_str;
+    hamiltonian->imag[term_idx] = 0.0;
+    hamiltonian->num_terms++;
+
+    //assert(hamiltonian->num_terms < __CQ_ANALOG_MAX_NUM_HAM_TERMS__);
+    if (hamiltonian->num_terms >= __CQ_ANALOG_MAX_NUM_HAM_TERMS__) {
+        printf("Error: Too many terms in the hamiltonian.\n");
+        return CQ_ERROR;
+    }
+
+    return CQ_SUCCESS;
+}
+
+
+
+cq_status add_xy_interaction_terms(analog_qreg *qreg, cq_hamiltonian *hamiltonian) {
+    assert(qreg != NULL);
+    assert(qreg->in_use);
+    assert(hamiltonian != NULL);
+
+    // assume systerm is C3 / hR**3 sum(j<i)(|1><0|i|0><1|j + |0><1|i|1><0|j)
+    // i.e. pauli+i pauli-j + pauli-i pauli+j
+    //
+    // pauli+ = X + iY
+    // pauli- = X - iY
+    //
+    // so hamil is: (Xi + iYi)(Xj - iYj) + (Xi - iYi)(Xj + iYj)
+    // XiXj - iXiYj + iYiXj + YiYj + XiXj + iXiYj - iYiXj + YiYj
+    // 2(XiXj + YiYj)
+
+    qreg->sys_terms_range.start = hamiltonian->num_terms;
+    for (int i = 0; i < qreg->num_qubits; ++i) {
+        for (int j = i + 1; j < qreg->num_qubits; ++j) {
+            //double interaction_str = xy_interaction(&qreg->qubit_pos[i],
+            //                                     &qreg->qubit_pos[j]);
+            double interaction_str = 0.0;
+            if(xy_interaction(&qreg->qubit_pos[i],
+                                 &qreg->qubit_pos[j],
+                                 &interaction_str) == CQ_ERROR) return CQ_ERROR;
+
+            interaction_str *= 2.0;
+            add_two_pauli_term(hamiltonian, 'X', 'X', i, j, interaction_str);
+            add_two_pauli_term(hamiltonian, 'Y', 'Y', i, j, interaction_str);
+        }
+    }
+
+    return CQ_SUCCESS;
+}
+
+cq_status add_interaction_terms(analog_qreg *qreg, cq_hamiltonian *hamiltonian) {
+    assert(qreg != NULL);
+    assert(qreg->in_use);
+    assert(hamiltonian != NULL);
+
+    device_mode mode = get_device_operating_mode();
+
+    switch (mode) {
+        case RYDBERG:
+            add_rydberg_interaction_terms(qreg, hamiltonian);
+            break;
+        case XY:
+            add_xy_interaction_terms(qreg, hamiltonian);
+            break;
+        default:
+            printf("UNKNOWN device mode.\n");
+            return CQ_ERROR;
+    }
+
+    return CQ_SUCCESS;
+}
+
+
+
+cq_status add_rydberg_interaction_terms(analog_qreg *qreg, cq_hamiltonian *hamiltonian) {
+    assert(qreg != NULL);
+    assert(qreg->in_use);
+    assert(hamiltonian != NULL);
+
+    // assume systerm is N0N1 where N = (1 - Z) / 2
+    // so we get 11 - 1Z - Z1 + ZZ
+
+    qreg->sys_terms_range.start = hamiltonian->num_terms;
+    for (int i = 0; i < qreg->num_qubits; ++i) {
+        for (int j = i + 1; j < qreg->num_qubits; ++j) {
+            //double interaction_str = ising_interaction(&qreg->qubit_pos[i],
+            //                                     &qreg->qubit_pos[j]);
+            double interaction_str = 0.0;
+            if(ising_interaction(&qreg->qubit_pos[i],
+                                 &qreg->qubit_pos[j],
+                                 &interaction_str) == CQ_ERROR) return CQ_ERROR;
+
+
+
+            add_two_pauli_term(hamiltonian, 'I', 'I', i, j, interaction_str);
+            add_two_pauli_term(hamiltonian, 'I', 'Z', i, j, -interaction_str);
+            add_two_pauli_term(hamiltonian, 'Z', 'I', i, j, -interaction_str);
+            add_two_pauli_term(hamiltonian, 'Z', 'Z', i, j, interaction_str);
+        }
+    }
+    qreg->sys_terms_range.end = hamiltonian->num_terms;
+    //print_hamil(hamiltonian);
+
+    return CQ_SUCCESS;
+}
+
+cq_status update_sys_terms(const analog_qreg *qreg, cq_hamiltonian *hamiltonian) {
+    assert(qreg != NULL);
+    assert(qreg->in_use);
+    assert(hamiltonian != NULL);
+
+    if (qreg->sys_terms_range.start == qreg->sys_terms_range.end) return CQ_SUCCESS;
+    ptrdiff_t coeff_idx = qreg->sys_terms_range.start;
+    for (ptrdiff_t i = 0; i < qreg->num_qubits; ++i) {
+        for (ptrdiff_t j = i + 1; j < qreg->num_qubits; ++j) {
+            //const double interaction_str = interaction(
+            //            &qreg->qubit_pos[i],
+            //            &qreg->qubit_pos[j]);
+
+            double interaction_str = 0.0;
+            if(interaction(&qreg->qubit_pos[i],
+                           &qreg->qubit_pos[j],
+                           &interaction_str) == CQ_ERROR) return CQ_ERROR;
+
+
+            hamiltonian->real[coeff_idx] = interaction_str;
+            hamiltonian->real[coeff_idx + 1] = -interaction_str;
+            hamiltonian->real[coeff_idx + 2] = -interaction_str;
+            hamiltonian->real[coeff_idx + 3] = interaction_str;
+            coeff_idx += 4;
+        }
+    }
+    return CQ_SUCCESS;
+}
+
+cq_status zero_driving_terms(
+    ptrdiff_t start, ptrdiff_t end,
+    const analog_qreg *qreg, cq_hamiltonian *hamiltonian) {
+    assert(qreg != NULL);
+    assert(qreg->in_use);
+    assert(hamiltonian != NULL);
+    assert(start > -1 && start < hamiltonian->num_terms);
+    assert(end >= start && end <= hamiltonian->num_terms);
+
+    for (ptrdiff_t i = start; i < end; ++i) {
+            hamiltonian->real[i] = 0.0;
+            hamiltonian->imag[i] = 0.0;
+    }
+
+    return CQ_SUCCESS;
+}
+
+cq_status reset_hamiltonian(cq_hamiltonian *hamiltonian) {
+    assert(hamiltonian != NULL);
+
+    for (ptrdiff_t i = 0; i < hamiltonian->num_terms; ++i) {
+        hamiltonian->real[i] = 0.0;
+        hamiltonian->imag[i] = 0.0;
+        hamiltonian->terms[i].num_paulis = 0;
+        hamiltonian->terms[i].var_idx = TERM_MODIFIER_RABI_COS;
+        hamiltonian->terms[i].sign = 1.0;
+    }
+    hamiltonian->num_terms = 0;
+    return CQ_SUCCESS;
+}
+
+#define RABI_SCALING_FACTOR 0.5
+#define DETUNING_SCALING_FACTOR 0.5
+
+double rabi_freq_cos_modifier(double freq, double phase, double detuning) {
+    return RABI_SCALING_FACTOR * freq * cos(phase);
+}
+
+double rabi_freq_sin_modifier(double freq, double phase, double detuning) {
+
+    return RABI_SCALING_FACTOR * freq * sin(phase);
+}
+
+double detuning_modifier(double freq, double phase, double detuning) {
+    return DETUNING_SCALING_FACTOR * detuning;
+}
+
+#undef DETUNING_SCALING_FACTOR
+#undef RABI_SCALING_FACTOR

--- a/src/device/analog/hamil.h
+++ b/src/device/analog/hamil.h
@@ -1,0 +1,57 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#ifndef CQ_ANALOG_HAMIL_H
+#define CQ_ANALOG_HAMIL_H
+
+#include "analog_datatypes.h"
+
+cq_status add_interaction_terms(analog_qreg *qreg, cq_hamiltonian *hamiltonian);
+
+// static and move to .c?
+cq_status add_rydberg_interaction_terms(analog_qreg *qreg, cq_hamiltonian *hamiltonian);
+cq_status add_xy_interaction_terms(analog_qreg *qreg, cq_hamiltonian *hamiltonian);
+
+cq_status add_driving_terms(analog_qreg *qreg, cq_hamiltonian *hamiltonian);
+
+// static and move to .c?
+cq_status add_rydberg_local_term(int target, cq_hamiltonian *hamiltonian);
+cq_status add_rydberg_global_term(analog_qreg *qreg, cq_hamiltonian *hamiltonian);
+cq_status add_raman_local_term(int target, cq_hamiltonian *hamiltonian);
+
+// this applies global detuning zero amp and negative detuing
+// adds -h/2 sum e * d(t) Z where e are the weights in the detuing map of atoms
+// A DetuningMap associates a set of locations with a set of weights. The locations are the trap coordinates to address and the weights have to be between 0 and 1.
+// SO this is Register thing
+cq_status add_dmm_global_term(analog_qreg *qreg);
+
+// TODO allow to select SC -- something like dwave with corresponding hamils
+
+cq_status update_sys_terms(const analog_qreg *qreg, cq_hamiltonian *hamiltonian);
+cq_status zero_driving_terms(ptrdiff_t start, ptrdiff_t end,
+                            const analog_qreg *qreg,
+                            cq_hamiltonian *hamiltonian);
+
+cq_status reset_hamiltonian(cq_hamiltonian *hamiltonian);
+
+typedef enum term_modifier_type {
+    TERM_MODIFIER_RABI_COS = 0,
+    TERM_MODIFIER_RABI_SIN,
+    TERM_MODIFIER_DETUNING,
+    TERM_MODIFIER_COUNT
+} term_modifier_type;
+
+double rabi_freq_cos_modifier(double freq, double phase, double detuning);
+double rabi_freq_sin_modifier(double freq, double phase, double detuning);
+double detuning_modifier(double freq, double phase, double detuning);
+
+typedef double (*term_modifier)(double, double, double);
+extern term_modifier term_modifiers[TERM_MODIFIER_COUNT];
+
+#endif // CQ_ANALOG_HAMIL_H

--- a/src/device/analog/pulse.c
+++ b/src/device/analog/pulse.c
@@ -1,0 +1,191 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#include "pulse.h"
+
+#include "analog_device.h"
+#include "simulator.h"
+#include "waveforms.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+static cq_status can_channel_play_pulse(channel *ch, pulse *pulse) {
+
+    assert(ch != NULL);
+    assert(ch->params != NULL);
+    assert(pulse != NULL);
+
+    channel_params *params = (channel_params *)ch->params;
+    if (pulse->duration < params->min_pulse_duration) {
+        printf("Error: Pulse duration is shorter than supported by channel.\n");
+        return CQ_ERROR;
+    }
+
+    if (pulse->duration > get_device_max_pulse_duration()) {
+        printf("Error: Pulse duration is longer than supported by device.\n");
+        return CQ_ERROR;
+    }
+
+    if (pulse->duration < get_device_min_pulse_duration()) {
+        printf("Error: Pulse duration is shorter than supported by device.\n");
+        return CQ_ERROR;
+    }
+
+    assert(params->sample_rate == get_device_sample_rate());
+    if (params->sample_rate != get_device_sample_rate()) {
+        printf("(internal) Error: Channel sample rate is not supported by device.\n");
+        return CQ_ERROR;
+    }
+
+    for (ptrdiff_t i = 0; i < pulse->num_samples; ++i) {
+        if (pulse->freq[i] > params->max_freq) {
+            printf("Error: Pulse frequency is above the channel threshold.\n");
+            return CQ_ERROR;
+        }
+        if (pulse->detuning[i] > params->max_detuning) {
+            printf("Error: Pulse detuning is above the channel threshold.\n");
+            return CQ_ERROR;
+        }
+
+        if (pulse->detuning[i] < -params->max_detuning) {
+            printf("Error: Pulse detuning is below the channel threshold.\n");
+            return CQ_ERROR;
+        }
+
+    }
+
+    return CQ_SUCCESS;
+}
+
+cq_status init_pulse(pulse *pulse, double duration) {
+    assert(pulse != NULL);
+    if (validate_duration(
+            duration,
+            get_device_min_pulse_duration(),
+            get_device_max_pulse_duration()) == CQ_ERROR) return CQ_ERROR;
+
+    pulse->duration = duration;
+    double sample_rate = get_device_sample_rate();
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+
+    validate_sampling(sample_rate, duration, num_samples);
+
+    pulse->num_samples = num_samples;
+
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        pulse->freq[i] = 0.0;
+        pulse->phase[i] = 0.0;
+        pulse->detuning[i] = 0.0;
+    }
+
+    return CQ_SUCCESS;
+}
+
+cq_status play(channel *ch, pulse *pulse) {
+    assert(ch != NULL);
+    assert(ch->params != NULL);
+    assert(pulse != NULL);
+
+    if (can_channel_play_pulse(ch, pulse) == CQ_ERROR) return CQ_ERROR;
+    channel_params *params = (channel_params *)ch->params;
+    assert(params != NULL);
+
+    int qreg_id = params->qreg_id;
+    assert(qreg_id > -1 && qreg_id < __CQ_ANALOG_MAX_NUM_QUREGS__);
+
+    analog_qreg *qreg = get_qreg(qreg_id);
+    assert(qreg != NULL);
+    assert(qreg->in_use);
+
+    cq_hamiltonian *hamiltonian = get_hamiltonian(qreg);
+    assert(hamiltonian != NULL);
+
+    simulate_pulse(ch, pulse, qreg, hamiltonian);
+    ch->time += pulse->duration;
+
+    return CQ_SUCCESS;
+}
+
+cq_status capture(channel *ch, pulse *pulse, int *result, int shots) {
+    assert(ch != NULL);
+    assert(ch->params != NULL);
+    assert(pulse != NULL);
+    assert(result != NULL);
+
+    if (can_channel_play_pulse(ch, pulse) == CQ_ERROR) {
+        return CQ_ERROR;
+    }
+
+    if (shots < 1 || shots > get_device_max_num_shots()) {
+        printf("Error: Invalid number of shots (%d). Should be "
+               "in [1, %d] range. From: %s\n",
+               shots,
+               get_device_max_num_shots(),
+               __func__);
+        return CQ_ERROR;
+    }
+
+    channel_params *params = (channel_params *)ch->params;
+    assert(params != NULL);
+    int qreg_id = params->qreg_id;
+    assert(qreg_id > -1 && qreg_id < __CQ_ANALOG_MAX_NUM_QUREGS__);
+    analog_qreg *qreg = get_qreg(qreg_id);
+    assert(qreg != NULL);
+    assert(qreg->in_use);
+
+    for (ptrdiff_t i = 0; i < shots; ++i) {
+        result[i] = simulate_capture(ch, qreg);
+        ch->time += pulse->duration;
+    }
+
+    return CQ_SUCCESS;
+}
+
+cq_status delay(channel *ch, double dt) {
+    assert(ch != NULL);
+    assert(ch->params != NULL);
+
+    if (validate_duration(
+            dt,
+            get_device_min_pulse_duration(),
+            get_device_max_pulse_duration()) == CQ_ERROR) return CQ_ERROR;
+    ch->time += dt;
+    return CQ_SUCCESS;
+}
+
+static cq_status validate_num_channels(int num_channels) {
+    if (num_channels < 1 || num_channels > __CQ_ANALOG_MAX_NUM_CHANNELS__) {
+        printf("Error: Provided wrong number of channels. "
+               "The num_channels should fall in range [1, %d], given: %d\n",
+               __CQ_ANALOG_MAX_NUM_CHANNELS__, num_channels);
+        return CQ_ERROR;
+    }
+    return CQ_SUCCESS;
+}
+
+cq_status barrier(channel **ch, int num_channels) {
+    assert(ch != NULL);
+
+    if (validate_num_channels(num_channels) == CQ_ERROR) return CQ_ERROR;
+
+    double max_time = 0.0;
+    for (ptrdiff_t i = 0; i < num_channels; ++i) {
+        assert(ch[i] != NULL);
+        //if (!ch[i]) return CQ_ERROR;
+        if (ch[i]->time > max_time) max_time = ch[i]->time;
+    }
+
+    for (ptrdiff_t i = 0; i < num_channels; ++i) {
+        if (ch[i]->time < max_time) delay(ch[i], max_time - ch[i]->time);
+    }
+    return CQ_SUCCESS;
+}
+
+

--- a/src/device/analog/pulse.h
+++ b/src/device/analog/pulse.h
@@ -1,0 +1,21 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#ifndef CQ_ANALOG_PULSE_H
+#define CQ_ANALOG_PULSE_H
+
+#include "analog_datatypes.h"
+
+cq_status init_pulse(pulse *pulse, double duration);
+cq_status play(channel *ch, pulse *pulse);
+cq_status capture(channel *ch, pulse *pulse, int *result, int shots);
+cq_status delay(channel *ch, double dt);
+cq_status barrier(channel **ch, int num_channels);
+
+#endif // CQ_ANALOG_PULSE_H

--- a/src/device/analog/simulator.c
+++ b/src/device/analog/simulator.c
@@ -1,0 +1,165 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#include "simulator.h"
+
+#include "analog_datatypes.h"
+#include "hamil.h"
+
+#include "../resources.h"
+#include "quest.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdbool.h>
+
+static PauliStrSum quest_hamiltonians[__CQ_ANALOG_MAX_NUM_QUREGS__] = {0};
+
+static cq_status get_pauli_strings(cq_hamiltonian *hamiltonian, PauliStr *pauli_strings) {
+    assert(hamiltonian != NULL);
+    assert(pauli_strings != NULL);
+    assert(hamiltonian->num_terms < __CQ_ANALOG_MAX_NUM_HAM_TERMS__);
+
+    for (int i = 0; i < hamiltonian->num_terms; ++i) {
+        const PauliStr quest_pauli_str = getPauliStr(
+            hamiltonian->terms[i].paulis,
+            hamiltonian->terms[i].indices,
+            hamiltonian->terms[i].num_paulis);
+
+        pauli_strings[i] = quest_pauli_str;
+    }
+
+    return CQ_SUCCESS;
+}
+
+static cq_status init_quest_hamiltonian(cq_hamiltonian *hamiltonian,
+                                PauliStrSum *quest_hamiltonian) {
+    assert(hamiltonian != NULL);
+
+    PauliStr pauli_strings[__CQ_ANALOG_MAX_NUM_HAM_TERMS__] = {0};
+    get_pauli_strings(hamiltonian, pauli_strings);
+
+    qcomp coeffs[__CQ_ANALOG_MAX_NUM_HAM_TERMS__] = {0};
+    for (ptrdiff_t i = 0; i < hamiltonian->num_terms; ++i) {
+        coeffs[i] = getQcomp(hamiltonian->real[i], hamiltonian->imag[i]);
+    }
+
+    *quest_hamiltonian = createPauliStrSum(pauli_strings, coeffs, hamiltonian->num_terms);
+    //reportPauliStrSum(*quest_hamiltonian);
+
+    return CQ_SUCCESS;
+}
+
+cq_status simulate_pulse(channel *ch, pulse *pulse, analog_qreg *qreg, cq_hamiltonian *hamiltonian) {
+    assert(ch != NULL);
+    assert(ch->params != NULL);
+    assert(pulse != NULL);
+    assert(qreg != NULL);
+    assert(hamiltonian != NULL);
+
+    int qreg_id = qreg->id;
+
+    if (quest_hamiltonians[qreg_id].numTerms == 0) {
+        init_quest_hamiltonian(hamiltonian, &quest_hamiltonians[qreg_id]);
+    }
+
+    channel_params *params = (channel_params *)ch->params;
+    double dt = params->sample_rate;
+    ptrdiff_t num_samples = pulse->num_samples;
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        for (ptrdiff_t j = qreg->channels_ranges[ch->id].start;
+             j < qreg->channels_ranges[ch->id].end; ++j) {
+
+            // TODO should coeffs be imag?
+            //double complex coeff = 0.0;
+            double coeff = 0.0;
+            double sign = hamiltonian->terms[j].sign;
+            coeff = sign * term_modifiers[hamiltonian->terms[j].var_idx](
+                            pulse->freq[i],
+                            pulse->phase[i],
+                            pulse->detuning[i]);
+
+            //hamiltonian.coeffs.data[j] = coeff;
+            // TODO: do I need imag after all?
+            hamiltonian->real[j] = coeff;
+            quest_hamiltonians[qreg_id].coeffs[j] = coeff;
+        }
+
+        applyTrotterizedPauliStrSumGadget(qregistry.registers[qreg_id],
+                                          quest_hamiltonians[qreg_id],
+                                          dt, 2, 4);
+    }
+
+    ptrdiff_t start = qreg->channels_ranges[ch->id].start;
+    ptrdiff_t end = qreg->channels_ranges[ch->id].end;
+    zero_driving_terms(start, end, qreg, hamiltonian);
+
+    for (ptrdiff_t i = start; i < end; ++i) {
+        quest_hamiltonians[qreg_id].coeffs[i] = 0.0;
+    }
+
+    return CQ_SUCCESS;
+}
+
+int simulate_capture(channel *ch, analog_qreg *qreg) {
+    assert(ch != NULL);
+    assert(ch->params != NULL);
+    assert(qreg != NULL);
+
+    return applyQubitMeasurement(
+            qregistry.registers[qreg->id],
+            ch->target);
+}
+
+void sync_simulator(cq_hamiltonian *hamiltonian, int qreg_id) {
+    assert(hamiltonian != NULL);
+    assert(qreg_id > -1 && qreg_id < __CQ_ANALOG_MAX_NUM_QUREGS__);
+
+    if (quest_hamiltonians[qreg_id].numTerms == 0) {
+        init_quest_hamiltonian(hamiltonian, &quest_hamiltonians[qreg_id]);
+    }
+
+    for (ptrdiff_t i = 0; i < hamiltonian->num_terms; ++i) {
+        quest_hamiltonians[qreg_id].coeffs[i] = getQcomp(hamiltonian->real[i],
+                                                         hamiltonian->imag[i]);
+    }
+}
+
+void print_statevec(int qreg_id) {
+    assert(qreg_id > -1 && qreg_id < __CQ_ANALOG_MAX_NUM_QUREGS__);
+    Qureg quest_qureg = qregistry.registers[qreg_id];
+    #define printbits_n(x,n) for (int j=n;j;j--,putchar('0'|(x>>j)&1))
+
+    for (int i = 0; i < quest_qureg.numAmps; ++i) {
+        double prob = creal(quest_qureg.cpuAmps[i]) * creal(quest_qureg.cpuAmps[i]) +
+                        cimag(quest_qureg.cpuAmps[i]) * cimag(quest_qureg.cpuAmps[i]);
+
+        printbits_n(i, quest_qureg.numQubits);
+        printf(" %f\n", prob);
+    }
+
+    #undef printbits_n
+}
+
+void init_simulator_qreg(int qreg_id, int num_qubits) {
+    if (!isQuESTEnvInit()) {
+        initQuESTEnv();
+    }
+
+    if (qregistry.available[qreg_id]) {
+        qregistry.available[qreg_id] = true;
+        qregistry.registers[qreg_id] = createQureg(num_qubits);
+    }
+}
+
+void reset_simulator_qreg(int qreg_id) {
+    assert(qreg_id > -1 && qreg_id < __CQ_ANALOG_MAX_NUM_QUREGS__);
+    initZeroState(qregistry.registers[qreg_id]);
+    //qregistry.available[qreg_id] = false;
+}

--- a/src/device/analog/simulator.h
+++ b/src/device/analog/simulator.h
@@ -1,0 +1,21 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#ifndef CQ_ANALOG_SIMULATOR_H
+#define CQ_ANALOG_SIMULATOR_H
+
+#include "analog_datatypes.h"
+
+cq_status simulate_pulse(channel *ch, pulse *pulse, analog_qreg *qreg, cq_hamiltonian *hamiltonian);
+int simulate_capture(channel *ch, analog_qreg *qreg);
+void sync_simulator(cq_hamiltonian *hamiltonian, int qreg_id);
+void print_statevec(int qreg_id);
+void init_simulator_qreg(int qreg_id, int num_qubits);
+void reset_simulator_qreg(int qreg_id);
+#endif // CQ_ANALOG_SIMULATOR_H

--- a/src/device/analog/waveforms.c
+++ b/src/device/analog/waveforms.c
@@ -1,0 +1,540 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#include "waveforms.h"
+
+#include "analog_device.h"
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+
+cq_status gaussian_wf(double *samples, double duration,
+                      double amp, double sigma) {
+
+    assert(samples != NULL);
+    if (validate_duration(duration,
+                          get_device_min_pulse_duration(),
+                          get_device_max_pulse_duration()) == CQ_ERROR) return CQ_ERROR;
+
+    double sample_rate = get_device_sample_rate();
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+
+    if (validate_sampling(sample_rate, duration, num_samples) == CQ_ERROR) return CQ_ERROR;
+    ptrdiff_t center = (ptrdiff_t)round(((double)num_samples / 2.0));
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        samples[i] = amp * exp(-((double)((i - center) * (i - center)) / (2 * sigma * sigma)));
+    }
+
+    return CQ_SUCCESS;
+}
+
+static double lifted_gaussian_sqr(double x, double risefall,
+                                  double width, double sigma) {
+    double sigma_sqr = sigma * sigma;
+    if (x < risefall) {
+        double numerator = x - risefall;
+        double numerator_sqr = numerator * numerator;
+        return exp(-0.5 * numerator_sqr / sigma_sqr);
+    } else if (x < risefall + width) {
+        return 1.0;
+    } else {
+        double offset = risefall + width;
+        double numerator = x - offset;
+        double numerator_sqr = numerator * numerator;
+        return exp(-0.5 * numerator_sqr / sigma_sqr);
+    }
+
+}
+
+cq_status gaussian_sqr_wf(double *samples, double duration, double amp,
+                          double sigma, double width) {
+    assert(samples != NULL);
+    if (validate_duration(duration,
+                          get_device_min_pulse_duration(),
+                          get_device_max_pulse_duration()) == CQ_ERROR) return CQ_ERROR;
+
+    double sample_rate = get_device_sample_rate();
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+    if (validate_sampling(sample_rate, duration, num_samples) == CQ_ERROR) return CQ_ERROR;
+    double risefall = (duration - width) / 2.0;
+
+    double df_minus_one = lifted_gaussian_sqr(-1.0, risefall, width, sigma);
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        double df = lifted_gaussian_sqr(((double)(i)),
+                                        risefall, width, sigma);
+
+        samples[i] = amp * (df - df_minus_one) / (1 - df_minus_one);
+    }
+
+    return CQ_SUCCESS;
+}
+
+// cubic polynomial specified by a, b, c, d
+// num equations 4N - 4
+#define __CQ_ANALOG_INTERPOLATION_MAX_POINTS__ 8
+#define __CQ_ANALOG_MAX_NUM_EQUATIONS__ 4 * __CQ_ANALOG_INTERPOLATION_MAX_POINTS__ - 4
+static double abs_mat_el(double value) {
+    if (value < 0.0) return -value;
+    return value;
+}
+
+static ptrdiff_t find_pivot(
+    double mat[__CQ_ANALOG_MAX_NUM_EQUATIONS__][__CQ_ANALOG_MAX_NUM_EQUATIONS__],
+    ptrdiff_t nrows, ptrdiff_t start, ptrdiff_t col) {
+
+    assert(mat != NULL);
+    assert(nrows > 0 && nrows <= __CQ_ANALOG_MAX_NUM_EQUATIONS__);
+    assert(start >= 0 && start < __CQ_ANALOG_MAX_NUM_EQUATIONS__);
+    assert(col >= 0 && col < __CQ_ANALOG_MAX_NUM_EQUATIONS__);
+
+    double max = mat[start][col];
+    ptrdiff_t argmax = start;
+    for (ptrdiff_t i = start + 1; i < nrows; ++i) {
+        if (abs_mat_el(mat[i][col]) > abs_mat_el(max)) {
+            max = mat[i][col];
+            argmax = i;
+        }
+    }
+    return argmax;
+}
+
+static void swap_rows(
+    double mat[__CQ_ANALOG_MAX_NUM_EQUATIONS__][__CQ_ANALOG_MAX_NUM_EQUATIONS__],
+    ptrdiff_t ncols, ptrdiff_t i, ptrdiff_t j) {
+
+    assert(mat != NULL);
+    assert(ncols > 0 && ncols <= __CQ_ANALOG_MAX_NUM_EQUATIONS__);
+    assert(i >= 0 && i < __CQ_ANALOG_MAX_NUM_EQUATIONS__);
+    assert(j >= 0 && j < __CQ_ANALOG_MAX_NUM_EQUATIONS__);
+
+    if (i != j) {
+        for (ptrdiff_t k = 0; k < ncols; ++k) {
+            double tmp = mat[i][k];
+            mat[i][k] = mat[j][k];
+            mat[j][k] = tmp;
+        }
+    }
+}
+
+static void gaussian_elim(
+    double mat[__CQ_ANALOG_MAX_NUM_EQUATIONS__][__CQ_ANALOG_MAX_NUM_EQUATIONS__],
+    ptrdiff_t nrows, ptrdiff_t ncols) {
+
+    assert(mat != NULL);
+    assert(nrows > 0 && nrows <= __CQ_ANALOG_MAX_NUM_EQUATIONS__);
+    assert(ncols > 0 && ncols <= __CQ_ANALOG_MAX_NUM_EQUATIONS__);
+
+    ptrdiff_t h = 0; /* Initialization of the pivot row */
+    ptrdiff_t k = 0; /* Initialization of the pivot column */
+
+    while (h < nrows && k < ncols) {
+        /* Find the k-th pivot: */
+        ptrdiff_t pivot_row = find_pivot(mat, nrows, h, k);
+        if (mat[pivot_row][k] == 0) {
+            ++k;
+        } else {
+            swap_rows(mat, ncols, h, pivot_row);
+            for (ptrdiff_t i = h + 1; i < nrows; ++i) {
+                double f = mat[i][k] / mat[h][k];
+                mat[i][k] = 0.0;
+                for (ptrdiff_t j = k + 1; j < ncols; ++j) {
+                    mat[i][j] -= mat[h][j] * f;
+                }
+            }
+        }
+        ++h;
+        ++k;
+    }
+}
+
+static void build_spline_problem(
+    double *points, int num_points, double interval,
+    double mat[__CQ_ANALOG_MAX_NUM_EQUATIONS__][__CQ_ANALOG_MAX_NUM_EQUATIONS__],
+    int *nrows_out, int *ncols_out) {
+
+    assert(points != NULL);
+    assert(num_points > 1);
+    assert(interval > 0.0);
+    assert(mat != NULL);
+    assert(nrows_out != NULL);
+    assert(ncols_out != NULL);
+
+    const int mat_size = 4 * num_points - 4;
+    const int nrows = mat_size;
+    const int ncols = nrows + 1;
+    const int num_poly = num_points - 1;
+
+    *nrows_out = nrows;
+    *ncols_out = ncols;
+
+    int row = 0;
+
+    // Cubic polynomials
+    for (ptrdiff_t i = 0; i < num_poly; i++, row += 2) {
+        // Poly i passes through points i and i+1.
+        double x = (double)i * interval;
+        mat[row][4 * i] =   x * x * x;
+        mat[row][4 * i + 1] = x * x;
+        mat[row][4 * i + 2] = x;
+        mat[row][4 * i + 3] = 1.0;
+        mat[row][ncols - 1] = points[i];
+
+        double x_next = x + interval;
+        mat[row + 1][4 * i] = x_next * x_next * x_next;
+        mat[row + 1][4 * i + 1] = x_next * x_next;
+        mat[row + 1][4 * i + 2] = x_next;
+        mat[row + 1][4 * i + 3] = 1.0;
+        mat[row + 1][ncols - 1] = points[i + 1];
+    }
+
+    // 1st derivative matching
+    for (ptrdiff_t i = 0; i < num_poly - 1; i++) {
+        // Poly i and poly i+1 must have the same first derivative at
+        // point i+1.
+        double x_next = (double)(i + 1) * interval;
+        mat[row][4 * i] = 3.0 * x_next * x_next;
+        mat[row][4 * i + 1] = 2.0 * x_next;
+        mat[row][4 * i + 2] = 1.0;
+        mat[row][4 * (i + 1)] = -3.0 * x_next * x_next;
+        mat[row][4 * (i + 1) + 1] = -2.0 * x_next;
+        mat[row][4 * (i + 1) + 2] = -1.0;
+        ++row;
+    }
+
+    // 2nd derivative matching
+    for (ptrdiff_t i = 0; i < num_poly - 1; i++) {
+        // Poly i and poly i+1 must have the same second derivative at
+        // point i+1.
+        double x_next = (double)(i + 1) * interval;
+        mat[row][4 * i] = 6.0 * x_next;
+        mat[row][4 * i + 1] = 2.0;
+        mat[row][4 * (i + 1)] = -6.0 * x_next;
+        mat[row][4 * (i + 1) + 1] = -2.0;
+        ++row;
+    }
+
+    // Boundry conditions
+    mat[row][0] = 0.0;
+    mat[row][1] = 2.0;
+    ++row;
+    mat[row][4 * (num_poly - 1)] = 6.0 * num_poly * interval;
+    mat[row][4 * (num_poly - 1) + 1] = 2.0;
+}
+
+static cq_status reduce_mat(
+    double *vec,
+    double mat[__CQ_ANALOG_MAX_NUM_EQUATIONS__][__CQ_ANALOG_MAX_NUM_EQUATIONS__],
+    int nrows, int ncols, int num_points) {
+
+    assert(vec != NULL);
+    assert(mat != NULL);
+    assert(nrows > 0 && nrows <= __CQ_ANALOG_MAX_NUM_EQUATIONS__);
+    assert(ncols > 0 && ncols <= __CQ_ANALOG_MAX_NUM_EQUATIONS__);
+    assert(num_points > 1);
+
+    const int mat_size = 4 * num_points - 4;
+    for (ptrdiff_t i = mat_size - 1; i >= 0; --i) {
+        // For each row, take its pivot and divide the last column by it,
+        // then eliminate the pivot from all rows above.
+        double pivot = mat[i][i];
+        double abs_pivot = pivot;
+        if (pivot < 0.0) abs_pivot = -abs_pivot;
+        if (abs_pivot < 0.0000000001) {
+            printf("Error: Waveform cannot be interpolated by cubic splines. "
+                   "From: %s", __func__);
+            return CQ_ERROR;
+        }
+
+        for (ptrdiff_t j = i - 1; j >= 0; --j) {
+            double f = mat[j][i] / pivot;
+            mat[j][i] = 0.0;
+            mat[j][ncols - 1] -= mat[i][ncols - 1] * f;
+        }
+        mat[i][i] = 1.0;
+        mat[i][ncols - 1] /= pivot;
+        vec[i] = mat[i][ncols - 1];
+    }
+    return CQ_SUCCESS;
+}
+
+static void interpolate(double *samples, ptrdiff_t num_samples,
+                        double *vec, int num_points, double interval) {
+    assert(samples != NULL);
+    assert(num_samples > 0);
+    assert(vec != NULL);
+    assert(num_points > 1);
+    assert(interval > 0.0);
+
+    int num_poly = num_points - 1;
+    double dx = (double)(num_samples) / (double)(num_samples - 1);
+    for (ptrdiff_t i = 0; i < num_poly; ++i) {
+        ptrdiff_t start = i * (ptrdiff_t)interval;
+        ptrdiff_t end = start + (ptrdiff_t)interval;
+
+        for (ptrdiff_t j = start; j < end; ++j) {
+            double x = (double)j * dx;
+
+            ptrdiff_t row = i * 4;
+            double y =  vec[row] * x * x * x +
+                        vec[row + 1] * x * x +
+                        vec[row + 2] * x +
+                        vec[row + 3];
+            samples[j] = y;
+        }
+    }
+}
+
+cq_status interpolated_wf(double *samples, double duration,
+                              double *points, int num_points) {
+    assert(samples != NULL);
+    assert(points != NULL);
+    assert(num_points > 1);
+    if (num_points > __CQ_ANALOG_INTERPOLATION_MAX_POINTS__) {
+        printf("Error: Interpolated waveform currently supports up "
+               "to %d points. From: %s\n",
+               __CQ_ANALOG_INTERPOLATION_MAX_POINTS__,
+               __func__);
+        return CQ_ERROR;
+    }
+
+    if (validate_duration(duration,
+            get_device_min_pulse_duration(),
+            get_device_max_pulse_duration()) == CQ_ERROR) return CQ_ERROR;
+
+
+    double sample_rate = get_device_sample_rate();
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+    if (validate_sampling(sample_rate, duration, num_samples) == CQ_ERROR) return CQ_ERROR;
+    double interval = (double)num_samples / (double)(num_points - 1);
+
+    double mat[__CQ_ANALOG_MAX_NUM_EQUATIONS__][__CQ_ANALOG_MAX_NUM_EQUATIONS__] = {0};
+    double vec[__CQ_ANALOG_MAX_NUM_EQUATIONS__] = {0};
+
+    int nrows;
+    int ncols;
+    build_spline_problem(points, num_points, interval, mat, &nrows, &ncols);
+    gaussian_elim(mat, nrows, ncols);
+    if(reduce_mat(vec, mat, nrows, ncols, num_points) == CQ_ERROR) {
+        return CQ_ERROR;
+    }
+    interpolate(samples, num_samples, vec, num_points, interval);
+
+    return CQ_SUCCESS;
+}
+
+#undef __CQ_ANALOG_MAX_NUM_EQUATIONS__
+
+cq_status custom_wf(double *samples, double *values, int num_samples) {
+    assert(samples != NULL);
+    assert(values != NULL);
+    assert(num_samples > 0);
+
+    double sample_rate = get_device_sample_rate();
+    double min_pulse_duration = get_device_min_pulse_duration();
+    double max_pulse_duration = get_device_max_pulse_duration();
+
+    if (num_samples / sample_rate > max_pulse_duration ||
+        num_samples / sample_rate < min_pulse_duration) {
+        printf("Error: The resulting custom waveform has duration not "
+               "supported by device.\n"
+               "Pulse duration should fall within [%f, %f] ns "
+               "given %f\n",
+               min_pulse_duration,
+               max_pulse_duration,
+               (double)num_samples / sample_rate);
+        return CQ_ERROR;
+    }
+
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        samples[i] = values[i];
+    }
+
+    return CQ_SUCCESS;
+}
+
+static double sech(double x) {
+    return 2.0 / (exp(x) + exp(-x));
+}
+
+cq_status sech_wf(double *samples, double duration, double amp, double sigma) {
+    assert(samples != NULL);
+    if (validate_duration(duration,
+                          get_device_min_pulse_duration(),
+                          get_device_max_pulse_duration()) == CQ_ERROR) return CQ_ERROR;
+
+    double sample_rate = get_device_sample_rate();
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+    if (validate_sampling(sample_rate, duration, num_samples) == CQ_ERROR) return CQ_ERROR;
+    ptrdiff_t center = (ptrdiff_t)round(((double)num_samples / 2.0));
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        samples[i] = amp * sech((double)(i - center) / sigma);
+    }
+
+    return CQ_SUCCESS;
+}
+
+cq_status sin_wf(double *samples, double duration, double amp,
+                 double freq, double phase) {
+    assert(samples != NULL);
+    if (validate_duration(duration,
+                          get_device_min_pulse_duration(),
+                          get_device_max_pulse_duration()) == CQ_ERROR) return CQ_ERROR;
+
+    double sample_rate = get_device_sample_rate();
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+    if (validate_sampling(sample_rate, duration, num_samples) == CQ_ERROR) return CQ_ERROR;
+
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        samples[i] = amp * sin(2 * M_PI * freq * (double)i/(double)num_samples + phase);
+    }
+
+    return CQ_SUCCESS;
+}
+
+cq_status cos_wf(double *samples, double duration, double amp,
+                 double freq, double phase) {
+    assert(samples != NULL);
+    if (validate_duration(duration,
+                          get_device_min_pulse_duration(),
+                          get_device_max_pulse_duration()) == CQ_ERROR) return CQ_ERROR;
+
+    double sample_rate = get_device_sample_rate();
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+    if (validate_sampling(sample_rate, duration, num_samples) == CQ_ERROR) return CQ_ERROR;
+
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        samples[i] = amp * cos(2 * M_PI * freq * (double)i/(double)num_samples + phase);
+    }
+
+    return CQ_SUCCESS;
+}
+
+cq_status blackman_wf(double *samples, double duration, double amp) {
+    assert(samples != NULL);
+    if (validate_duration(duration,
+                          get_device_min_pulse_duration(),
+                          get_device_max_pulse_duration()) == CQ_ERROR) return CQ_ERROR;
+
+    double sample_rate = get_device_sample_rate();
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+    if (validate_sampling(sample_rate, duration, num_samples) == CQ_ERROR) return CQ_ERROR;
+
+#define BLACKMAN_A0_COEFF 0.42659
+#define BLACKMAN_A1_COEFF 0.49656
+#define BLACKMAN_A2_COEFF 0.076849
+
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        double ratio = (double)i / (double)num_samples;
+        samples[i] = amp * (BLACKMAN_A0_COEFF -
+                            BLACKMAN_A1_COEFF * cos(2 * M_PI * ratio) +
+                            BLACKMAN_A2_COEFF * cos(4 * M_PI * ratio));
+    }
+
+#undef BLACKMAN_A0_COEFF
+#undef BLACKMAN_A1_COEFF
+#undef BLACKMAN_A2_COEFF
+
+    return CQ_SUCCESS;
+}
+
+static double repeater(double x, double freq, double phase) {
+    return x * freq + (phase / 2 * M_PI);
+}
+
+cq_status saw_wf(double *samples, double duration, double amp,
+                 double freq, double phase) {
+    assert(samples != NULL);
+    if (validate_duration(duration,
+                          get_device_min_pulse_duration(),
+                          get_device_max_pulse_duration()) == CQ_ERROR) return CQ_ERROR;
+
+    double sample_rate = get_device_sample_rate();
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+    if (validate_sampling(sample_rate, duration, num_samples) == CQ_ERROR) return CQ_ERROR;
+
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        double x = (double)i / (double)num_samples;
+        double wav = repeater(x, freq, phase);
+        samples[i] = 2 * amp * (wav - floor(wav + 0.5));
+    }
+
+    return CQ_SUCCESS;
+}
+
+cq_status composite_wf(double *samples, double **waveforms,
+                       ptrdiff_t *num_samples, int num_waveforms,
+                       ptrdiff_t *total_num_samples) {
+    assert(samples != NULL);
+    assert(waveforms != NULL);
+    assert(num_samples != NULL);
+    assert(num_waveforms > 0);
+    assert(total_num_samples != NULL);
+
+    double sample_rate = get_device_sample_rate();
+    double min_pulse_duration = get_device_min_pulse_duration();
+    double max_pulse_duration = get_device_max_pulse_duration();
+
+    ptrdiff_t k = 0;
+    for (ptrdiff_t i = 0; i < num_waveforms; ++i) {
+        for (ptrdiff_t j = 0; j < num_samples[i]; ++j) {
+            samples[k] = waveforms[i][j];
+            ++k;
+        }
+    }
+
+
+    *total_num_samples = k;
+    if ((double)k / sample_rate > max_pulse_duration ||
+        (double)k / sample_rate < min_pulse_duration) {
+        printf("Error: The resulting composite waveform has duration not "
+               "supported by device.\n"
+               "Pulse duration should fall within [%f, %f] ns "
+               "given %f\n",
+               min_pulse_duration,
+               max_pulse_duration,
+               (double)k / sample_rate);
+
+        return CQ_ERROR;
+    }
+
+    return CQ_SUCCESS;
+}
+
+cq_status validate_duration(double duration, double min_duration, double max_duration) {
+    if (duration < min_duration ||
+        duration > max_duration) {
+        printf("Error: Pulse duration should fall within [%f, %f] ns "
+               "given %f\n",
+               min_duration,
+               max_duration,
+               duration);
+        return CQ_ERROR;
+    }
+
+    return CQ_SUCCESS;
+}
+
+cq_status validate_sampling(double sample_rate, double duration, ptrdiff_t num_samples) {
+    if (((duration * sample_rate) - (double)num_samples) > __CQ_ANALOG_EPSILON__) {
+        printf("Warning: Requested pulse duration "
+               "produces non-integer number of samples. "
+               "Proceeding, but sampling errors are expected.\n");
+        return CQ_WARNING;
+    }
+
+    if (num_samples < 1 || num_samples > __CQ_ANALOG_MAX_NUM_SAMPLES__) {
+        printf("Error: Given waveform requires too many samples. "
+               "Current maximum number of samples is: %d\n",
+               __CQ_ANALOG_MAX_NUM_SAMPLES__);
+        return CQ_ERROR;
+    }
+
+    return CQ_SUCCESS;
+}

--- a/src/device/analog/waveforms.h
+++ b/src/device/analog/waveforms.h
@@ -1,0 +1,38 @@
+/**
+* @author Mateusz Meller
+*
+* @copyright Copyright (c) 2025
+* UK Research and Innovation,
+* Science and Technology Facilities Council,
+* Hartree Centre
+*/
+
+#ifndef CQ_ANALOG_WAVEFORMS_H
+#define CQ_ANALOG_WAVEFORMS_H
+
+#include "analog_datatypes.h"
+
+cq_status gaussian_wf(double *samples, double duration, double amp, double sigma);
+cq_status gaussian_sqr_wf(double *samples, double duration, double amp,
+                          double sigma, double width);
+
+cq_status interpolated_wf(double *samples, double duration,
+                          double *points, int num_points);
+cq_status sech_wf(double *samples, double duration, double amp, double sigma);
+cq_status sin_wf(double *samples, double duration, double amp,
+                 double freq, double phase);
+cq_status cos_wf(double *samples, double duration, double amp,
+                 double freq, double phase);
+cq_status blackman_wf(double *samples, double duration, double amp);
+cq_status saw_wf(double *samples, double duration, double amp,
+                 double freq, double phase);
+cq_status custom_wf(double *samples, double *values, int num_samples);
+cq_status composite_wf(double *samples, double **waveforms,
+                       ptrdiff_t *num_samples, int num_waveforms,
+                       ptrdiff_t *total_num_samples);
+
+// utils
+cq_status validate_duration(double duration, double min_duration, double max_duration);
+cq_status validate_sampling(double sample_rate, double duration, ptrdiff_t num_samples);
+
+#endif // CQ_ANALOG_WAVEFORMS_H

--- a/src/host/utils.c
+++ b/src/host/utils.c
@@ -1,5 +1,6 @@
 #include "datatypes.h"
 #include "utils.h"
+#include <stdio.h>
 
 void init_creg(const size_t LENGTH, const cstate INIT_VAL, cstate * cr) {
   for (size_t i = 0; i < LENGTH; ++i) {

--- a/src/host/utils.c
+++ b/src/host/utils.c
@@ -7,3 +7,19 @@ void init_creg(const size_t LENGTH, const cstate INIT_VAL, cstate * cr) {
   }
   return;
 }
+
+void report_results(
+  cstate const * const CR,
+  const size_t NMEASURE,
+  const size_t NSHOTS) {
+  printf("Reporting measurement outcomes:\n");
+  for (size_t shot = 0; shot < NSHOTS; ++shot) {
+    printf("Shot [%lu]: ", shot);
+    for (size_t i = shot * NMEASURE; i < (shot + 1) * NMEASURE; ++i) {
+      printf("%d ", CR[i]);
+    }
+    printf("\n");
+  }
+
+  return;
+}

--- a/tests/device/CMakeLists.txt
+++ b/tests/device/CMakeLists.txt
@@ -94,3 +94,5 @@ add_test(
   NAME test_qasm_gates
   COMMAND ./test_qasm_gates
 )
+
+add_subdirectory(analog)

--- a/tests/device/analog/CMakeLists.txt
+++ b/tests/device/analog/CMakeLists.txt
@@ -1,0 +1,35 @@
+find_library(MATHS_LIBRARY m REQUIRED)
+
+# ------------------------ analog ops -----------------------------
+add_executable(test_analog
+  test_analog.c
+)
+
+target_link_libraries(test_analog
+  PRIVATE
+  CQ-SIMBE::cq-simbe
+  unity::framework
+  QuEST::QuEST
+)
+
+add_test(
+  NAME test_analog
+  COMMAND ./test_analog
+)
+
+# ------------------------ waveforms ------------------------------
+add_executable(test_waveforms
+  test_waveforms.c
+)
+
+target_link_libraries(test_waveforms
+  PRIVATE
+  CQ-SIMBE::cq-simbe
+  unity::framework
+)
+
+add_test(
+  NAME test_waveforms
+  COMMAND ./test_waveforms
+)
+

--- a/tests/device/analog/test_analog.c
+++ b/tests/device/analog/test_analog.c
@@ -1,0 +1,466 @@
+#include "unity.h"
+
+#include "analog.h"
+#include "src/device/resources.h"
+#include "src/device/control.h"
+
+#include <stdbool.h>
+
+void setUp(void) {
+    int param = 0;
+    initialise_simulator(&param);
+    const size_t NQUBITS = 5;
+    int idx = get_next_available_qregistry_slot();
+    qregistry.registers[idx] = createQureg(NQUBITS);
+    qregistry.available[idx] = false;
+    ++qregistry.num_registers;
+    return;
+}
+
+void tearDown(void) {
+    int param = 0;
+    //finalise_simulator(&param);
+    return;
+}
+
+void test_cq_enable_analog_mode(void) {
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, cq_enable_analog_mode(RYDBERG));
+    // Re-initialization should fail
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_enable_analog_mode(RYDBERG));
+    cq_print_analog_device();
+    cq_print_avail_channels();
+}
+
+void test_cq_duration_to_samples(void) {
+    double duration = 400;
+    ptrdiff_t expected = 100;
+
+    TEST_ASSERT_EQUAL_INT(expected, cq_duration_to_samples(duration));
+    TEST_ASSERT_EQUAL_INT(0, cq_duration_to_samples(-42.0));
+}
+
+void test_cq_samples_to_duration(void) {
+    double num_samples = 100;
+    ptrdiff_t expected = 400;
+    double epsilon = 0.0000001;
+
+    TEST_ASSERT(expected - cq_samples_to_duration(num_samples) < epsilon);
+    TEST_ASSERT(0.0 - cq_samples_to_duration(-12) < epsilon);
+}
+
+void test_cq_enable_analog_qreg(void) {
+    // Good inputs
+    int qreg_id = 0;
+    int num_qubits = 2;
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, cq_enable_analog_qreg(qreg_id, num_qubits));
+
+    // Re-initialization should fail
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_enable_analog_qreg(qreg_id, num_qubits));
+
+    // Bad qreg_id
+    qreg_id = 128;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_enable_analog_qreg(qreg_id, num_qubits));
+    qreg_id = -2;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_enable_analog_qreg(qreg_id, num_qubits));
+
+    qreg_id = 0;
+    // Bad num_qubits
+    num_qubits = -3;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_enable_analog_qreg(qreg_id, num_qubits));
+    num_qubits = 124;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_enable_analog_qreg(qreg_id, num_qubits));
+    num_qubits = 0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_enable_analog_qreg(qreg_id, num_qubits));
+
+    // Disabling and re-enabling qreg with different size should work
+    num_qubits = 3;
+    cq_disable_analog_qreg(qreg_id);
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, cq_enable_analog_qreg(qreg_id, num_qubits));
+
+    // "Large" number of qubits should succeed
+    // (there should be sufficient memory for all internal functions)
+    //num_qubits = 59;  // ofc fails at quest level
+    //num_qubits = 29;  // succeeds but takes a while
+    num_qubits = 27;    // "big" and fast
+    cq_disable_analog_qreg(qreg_id);
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, cq_enable_analog_qreg(qreg_id, num_qubits));
+}
+
+void test_cq_disable_analog_mode(void) {
+    // Good inputs
+    int qreg_id = 0;
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, cq_disable_analog_qreg(qreg_id));
+
+    // Repeating on the same qreg should fail
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_disable_analog_qreg(qreg_id));
+
+    // Bad qreg_id
+    qreg_id = -1;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_disable_analog_qreg(qreg_id));
+
+    qreg_id = 128;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_disable_analog_qreg(qreg_id));
+}
+
+void test_cq_get_global_channel(void) {
+    channel ch0 = {0};
+    channel ch1;
+    int global_type = 0; // aka RYDBERG_GLOBAL
+    int qreg_id = 0;
+    int num_qubits = 5;
+    double epsilon = 0.0000001;
+
+    // Getting channel on uninitialised qreg.
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_global_channel(&ch0, global_type, qreg_id));
+
+    cq_enable_analog_qreg(qreg_id, num_qubits);
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_get_global_channel(&ch0, global_type, qreg_id));
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, cq_print_channel(&ch0));
+
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_get_global_channel(&ch1, global_type, qreg_id));
+    TEST_ASSERT_EQUAL_INT(ch0.id, ch1.id);
+    TEST_ASSERT_EQUAL_INT(ch0.type, ch1.type);
+    TEST_ASSERT_EQUAL_INT(ch0.target, ch1.target);
+    TEST_ASSERT(ch0.time < epsilon);
+    TEST_ASSERT(ch1.time < epsilon);
+    TEST_ASSERT(ch0.time - ch1.time < epsilon);
+
+    // NULL channel
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_global_channel(NULL, global_type, qreg_id));
+
+    int negative_type = -1;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_global_channel(&ch0, negative_type, qreg_id));
+
+    int local_type = 1; // aka RYDBERG_LOCAL
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_global_channel(&ch0, local_type, qreg_id));
+
+    int unknown_type = 4;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_global_channel(&ch0, unknown_type, qreg_id));
+
+    // Bad qreg_id
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_global_channel(&ch0, 0, -1));
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_global_channel(&ch0, 0, 128));
+}
+
+void test_cq_get_local_channel(void) {
+    channel ch0 = {0};
+    int local_type = 1; // aka RYDBERG_LOCAL
+    int qreg_id = 0;
+    int target = 0;
+    int num_qubits = 5;
+
+    cq_disable_analog_qreg(qreg_id);
+    cq_enable_analog_qreg(qreg_id, num_qubits);
+
+
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_get_local_channel(
+                              &ch0, local_type, target, qreg_id));
+
+    // NULL channel
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_local_channel(
+                              NULL, local_type, target, qreg_id));
+
+    // Bad channel types
+    int negative_type = -1;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_local_channel(
+                              &ch0, negative_type, target, qreg_id));
+    int global_type = 0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_local_channel(
+                              &ch0, global_type, target, qreg_id));
+
+    int unknown_type = 4;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_local_channel(
+                              &ch0, unknown_type, target, qreg_id));
+
+    // Bad target
+    int negative_target = -1;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_local_channel(
+                              &ch0, local_type, negative_target, qreg_id));
+
+    int target_bigger_than_num_qubits = num_qubits;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_local_channel(
+                              &ch0, local_type,
+                              target_bigger_than_num_qubits, qreg_id));
+
+
+    int too_big_target = 128;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_local_channel(
+                              &ch0, local_type, too_big_target, qreg_id));
+
+    // Bad qreg id
+    int negative_qreg_id = -1;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_local_channel(
+                              &ch0, local_type, target, negative_qreg_id));
+
+    int too_big_qreg_id = 254;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_get_local_channel(
+                              &ch0, local_type, target, too_big_target));
+
+
+}
+
+void test_cq_update_qreg_pos(void) {
+    int num_qubits = 5;
+    int qreg_id = 0;
+    cq_disable_analog_qreg(qreg_id);
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_print_qpos(qreg_id));
+    cq_enable_analog_qreg(qreg_id, num_qubits);
+
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, cq_print_qpos(qreg_id));
+
+    qpos new_pos[5] = {
+        {5.0, 5.0, 0.0},
+        {15.0, 15.0, 0.0},
+        {25.0, 25.0, 0.0},
+        {35.0, 35.0, 0.0},
+        {45.0, 45.0, 0.0},
+    };
+
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_update_qreg_pos(new_pos, num_qubits, qreg_id));
+
+    cq_print_qpos(qreg_id);
+    qpos bad_pos[5] = {
+        {2.0, 5.0, 0.0},
+        {3.0, 1.0, 0.0},
+        {4.0, 0.0, 0.0},
+        {5.0, 0.0, 0.0},
+        {6.0, 0.0, 0.0},
+    };
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_update_qreg_pos(bad_pos, num_qubits, qreg_id));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_update_qreg_pos(NULL, num_qubits, qreg_id));
+
+    int neg_num_qubits = -1;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_update_qreg_pos(new_pos, neg_num_qubits, qreg_id));
+
+
+    int bad_num_qubits = num_qubits + 1;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_update_qreg_pos(new_pos, bad_num_qubits, qreg_id));
+
+    int negative_qreg_id = -2;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_update_qreg_pos(new_pos, num_qubits, negative_qreg_id));
+
+
+    int too_big_qreg_id = num_qubits;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_update_qreg_pos(new_pos, num_qubits, too_big_qreg_id));
+
+}
+
+void test_cq_init_pulse(void) {
+    pulse p = {0};
+    double duration = 100.0;
+
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_init_pulse(&p, duration));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_init_pulse(NULL, duration));
+
+    double negative_duration = -100.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_init_pulse(&p, negative_duration));
+
+    double too_long_duration = 10000000000.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_init_pulse(&p, too_long_duration));
+
+}
+
+void test_cq_play(void) {
+    pulse p = {0};
+    channel ch = {0};
+    double duration = 100.0;
+
+    int qreg_id = 0;
+    int num_qubits = 5;
+    cq_disable_analog_qreg(qreg_id);
+    cq_enable_analog_qreg(qreg_id, num_qubits);
+
+    cq_get_local_channel(&ch, 1, 0, 0);
+
+    // uninitialised pulse fails to play
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_play(&ch, &p));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_play(NULL, &p));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_play(&ch, NULL));
+
+    // Can play initialised but "empty" pulses
+    cq_init_pulse(&p, duration);
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_play(&ch, &p));
+
+    // Empty pulse will result in no change of statevector
+    // If we start in zero state we will get 0 when measuring.
+    int results[1];
+    int num_shots = 1;
+    cq_capture(&ch, &p, results, num_shots);
+    TEST_ASSERT_EQUAL_INT(0, results[0]);
+
+    // This pulse should put the statevector in |1> state.
+    //double interpolation_points[3] = {0.785, 0.785, 0.785};
+    //cq_interpolated_wf(p.freq, duration, interpolation_points, 3);
+    cq_gaussian_wf(p.freq, duration, 2.5103, 2.0);
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_play(&ch, &p));
+    cq_capture(&ch, &p, results, num_shots);
+    TEST_ASSERT_EQUAL_INT(1, results[0]);
+
+}
+
+void test_cq_capture(void) {
+    int num_qubits = 5;
+    int qreg_id = 0;
+    cq_disable_analog_qreg(qreg_id);
+    cq_enable_analog_qreg(qreg_id, num_qubits);
+
+    channel ch = {0};
+    pulse p = {0};
+    int results[10];
+    int num_shots = 10;
+    double duration = 100.0;
+    double epsilon = 0.0000001;
+
+    // Only local channel can capture
+    cq_get_global_channel(&ch, 0, 0);
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_capture(&ch, &p, results, num_shots));
+
+    cq_get_local_channel(&ch, 1, 0, 0);
+
+    // uninitialised pulse fails to capture
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_capture(&ch, &p, results, num_shots));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_capture(NULL, &p, results, num_shots));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_capture(&ch, NULL, results, num_shots));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_capture(&ch, &p, NULL, num_shots));
+
+
+    // Currently the pulse shape has no impact on the capture
+    // so it suffices to initialise it.
+    cq_init_pulse(&p, duration);
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_capture(&ch, &p, results, num_shots));
+
+    TEST_ASSERT(ch.time - (duration * num_shots) < epsilon);
+
+    TEST_ASSERT_EQUAL_INT(0, results[0]);
+
+    int neg_num_shots = -1;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_capture(&ch, &p, results, neg_num_shots));
+
+    int too_big_num_shots = 40000;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_capture(&ch, &p, results, too_big_num_shots));
+
+}
+
+void test_cq_delay(void) {
+    channel ch = {0};
+    double dt = 20.0;
+    double epsilon = 0.0000001;
+
+    // uninitialised channel fails to delay
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_delay(&ch, dt));
+
+    cq_get_global_channel(&ch, 0, 0);
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, cq_delay(&ch, dt));
+    TEST_ASSERT(ch.time - dt < epsilon);
+
+    double negative_dt = -5.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_delay(&ch, negative_dt));
+    double too_short_dt = 5.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_delay(&ch, too_short_dt));
+    double too_long_dt = 50000000000.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_delay(&ch, too_long_dt));
+}
+
+void test_cq_barrier(void) {
+    channel ch0 = {0};
+    channel ch1 = {0};
+    channel ch2 = {0};
+    channel ch3 = {0};
+    channel ch4 = {0};
+
+    channel *channels[5] = {&ch0, &ch1, &ch2, &ch3, &ch4};
+    int num_qubits = 5;
+    int qreg_id = 0;
+    double epsilon = 0.0000001;
+
+    cq_disable_analog_qreg(qreg_id);
+    cq_enable_analog_qreg(qreg_id, num_qubits);
+
+    // barrier on uninitialised channels fails
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_barrier(channels, num_qubits));
+
+    for (ptrdiff_t i = 0; i < num_qubits; ++i) {
+        cq_get_local_channel(channels[i], 1, i, 0);
+    }
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, cq_barrier(channels, num_qubits));
+    TEST_ASSERT(channels[0]->time - channels[1]->time < epsilon &&
+                channels[1]->time - channels[2]->time < epsilon &&
+                channels[2]->time - channels[3]->time < epsilon &&
+                channels[3]->time - channels[4]->time < epsilon);
+
+
+    int neg_num_qubits = -1;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_barrier(channels, neg_num_qubits));
+}
+
+// not needed when using generate_test_runner.rb
+int main(void) {
+    UNITY_BEGIN();
+    setUp();
+    RUN_TEST(test_cq_enable_analog_mode);
+    RUN_TEST(test_cq_samples_to_duration);
+    RUN_TEST(test_cq_duration_to_samples);
+    RUN_TEST(test_cq_enable_analog_qreg);
+    RUN_TEST(test_cq_disable_analog_mode);
+    RUN_TEST(test_cq_get_global_channel);
+    RUN_TEST(test_cq_get_local_channel);
+    RUN_TEST(test_cq_update_qreg_pos);
+    RUN_TEST(test_cq_init_pulse);
+    RUN_TEST(test_cq_play);
+    RUN_TEST(test_cq_capture);
+    RUN_TEST(test_cq_delay);
+    RUN_TEST(test_cq_barrier);
+    tearDown();
+    return UNITY_END();
+}

--- a/tests/device/analog/test_waveforms.c
+++ b/tests/device/analog/test_waveforms.c
@@ -1,0 +1,706 @@
+#include "unity.h"
+
+#include "analog.h"
+
+void setUp(void) {
+    cq_enable_analog_mode(RYDBERG);
+    return;
+}
+
+void tearDown(void) {
+    return;
+}
+
+void test_cq_gaussian_wf(void) {
+    double expected[100] = {
+        5.31236408e-242, 1.90443622e-232, 4.37749104e-223, 6.45155387e-214,
+        6.09654271e-205, 3.69388307e-196, 1.43503633e-187, 3.57456238e-179,
+        5.70904011e-171, 5.84633286e-163, 3.83870035e-155, 1.61608841e-147,
+        4.36240770e-140, 7.55035926e-133, 8.37894253e-126, 5.96198717e-119,
+        2.72002624e-112, 7.95674389e-106, 1.49237476e-099, 1.79473628e-093,
+        1.38389653e-087, 6.84205918e-082, 2.16895361e-076, 4.40853133e-071,
+        5.74536772e-066, 4.80089224e-061, 2.57220937e-056, 8.83630922e-052,
+        1.94632663e-047, 2.74878501e-043, 2.48912125e-039, 1.44521201e-035,
+        5.38018616e-032, 1.28423137e-028, 1.96548382e-025, 1.92874985e-022,
+        1.21356367e-019, 4.89586526e-017, 1.26641655e-014, 2.10040929e-012,
+        2.23363144e-010, 1.52299797e-008, 6.65836147e-007, 1.86644691e-005,
+        3.35462628e-004, 3.86592014e-003, 2.85655008e-002, 1.35335283e-001,
+        4.11112291e-001, 8.00737403e-001, 1.00000000e+000, 8.00737403e-001,
+        4.11112291e-001, 1.35335283e-001, 2.85655008e-002, 3.86592014e-003,
+        3.35462628e-004, 1.86644691e-005, 6.65836147e-007, 1.52299797e-008,
+        2.23363144e-010, 2.10040929e-012, 1.26641655e-014, 4.89586526e-017,
+        1.21356367e-019, 1.92874985e-022, 1.96548382e-025, 1.28423137e-028,
+        5.38018616e-032, 1.44521201e-035, 2.48912125e-039, 2.74878501e-043,
+        1.94632663e-047, 8.83630922e-052, 2.57220937e-056, 4.80089224e-061,
+        5.74536772e-066, 4.40853133e-071, 2.16895361e-076, 6.84205918e-082,
+        1.38389653e-087, 1.79473628e-093, 1.49237476e-099, 7.95674389e-106,
+        2.72002624e-112, 5.96198717e-119, 8.37894253e-126, 7.55035926e-133,
+        4.36240770e-140, 1.61608841e-147, 3.83870035e-155, 5.84633286e-163,
+        5.70904011e-171, 3.57456238e-179, 1.43503633e-187, 3.69388307e-196,
+        6.09654271e-205, 6.45155387e-214, 4.37749104e-223, 1.90443622e-232};
+
+    double samples[100] = {0};
+    double duration = 313.0;
+    double amp = 1.0;
+    double sigma = 1.5;
+    double epsilon = 0.0000001;
+
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, cq_gaussian_wf(samples, duration, amp, sigma));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR, cq_gaussian_wf(NULL, duration, amp, sigma));
+
+    double negative_duration = -1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_gaussian_wf(samples, negative_duration, amp, sigma));
+
+
+    double too_short_duration = 1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_gaussian_wf(samples, too_short_duration, amp, sigma));
+
+    double too_long_duration = 4000000001.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_gaussian_wf(samples, too_long_duration, amp, sigma));
+
+    duration = 400.0;
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, cq_gaussian_wf(samples, duration, amp, sigma));
+
+    double sample_rate = 0.25;
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        TEST_ASSERT(samples[i] - expected[i] < epsilon);
+    }
+}
+
+void test_cq_gaussian_sqr_wf(void) {
+    double samples[100] = {0};
+    double duration = 313.0;
+    double amp = 1.0;
+    double sigma = 1.5;
+    double width = 100.5;
+    double epsilon = 0.0000001;
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_gaussian_sqr_wf(
+                              samples, duration, amp, sigma, width));
+}
+
+void test_cq_interpolated_wf(void) {
+    double expected[100] = {
+        -5.000000, -4.898990, -4.797980, -4.696970, -4.595960,
+        -4.494949, -4.393939, -4.292929, -4.191919, -4.090909,
+        -3.989899, -3.888889, -3.787879, -3.686869, -3.585859,
+        -3.484848, -3.383838, -3.282828, -3.181818, -3.080808,
+        -2.979798, -2.878788, -2.777778, -2.676768, -2.575758,
+        -2.474747, -2.373737, -2.272727, -2.171717, -2.070707,
+        -1.969697, -1.868687, -1.767677, -1.666667, -1.565657,
+        -1.464646, -1.363636, -1.262626, -1.161616, -1.060606,
+        -0.959596, -0.858586, -0.757576, -0.656566, -0.555556,
+        -0.454545, -0.353535, -0.252525, -0.151515, -0.050505,
+        0.050505, 0.151515, 0.252525, 0.353535, 0.454545,
+        0.555556, 0.656566, 0.757576, 0.858586, 0.959596,
+        1.060606, 1.161616, 1.262626, 1.363636, 1.464646,
+        1.565657, 1.666667, 1.767677, 1.868687, 1.969697,
+        2.070707, 2.171717, 2.272727, 2.373737, 2.474747,
+        2.575758, 2.676768, 2.777778, 2.878788, 2.979798,
+        3.080808, 3.181818, 3.282828, 3.383838, 3.484848,
+        3.585859, 3.686869, 3.787879, 3.888889, 3.989899,
+        4.090909, 4.191919, 4.292929, 4.393939, 4.494949,
+        4.595960, 4.696970, 4.797980, 4.898990, 5.000000
+    };
+
+    double expected2[100] = {
+        0.000000, 0.095081, 0.190084, 0.284933, 0.379548,
+        0.473853, 0.567769, 0.661220, 0.754128, 0.846415,
+        0.938003, 1.028815, 1.118773, 1.207799, 1.295817,
+        1.382748, 1.468515, 1.553039, 1.636244, 1.718052,
+        1.798386, 1.877167, 1.954317, 2.029761, 2.103419,
+        2.175214, 2.245068, 2.312905, 2.378645, 2.442213,
+        2.503529, 2.562517, 2.619099, 2.673196, 2.724733,
+        2.773630, 2.819810, 2.863197, 2.903711, 2.941276,
+        2.975813, 3.007246, 3.035496, 3.060487, 3.082139,
+        3.100377, 3.115121, 3.126295, 3.133821, 3.137621,
+        3.137621, 3.133821, 3.126295, 3.115121, 3.100377,
+        3.082139, 3.060487, 3.035496, 3.007246, 2.975813,
+        2.941276, 2.903711, 2.863197, 2.819810, 2.773630,
+        2.724733, 2.673196, 2.619099, 2.562517, 2.503529,
+        2.442213, 2.378645, 2.312905, 2.245068, 2.175214,
+        2.103419, 2.029761, 1.954317, 1.877167, 1.798386,
+        1.718052, 1.636244, 1.553039, 1.468515, 1.382748,
+        1.295817, 1.207799, 1.118773, 1.028815, 0.938003,
+        0.846415, 0.754128, 0.661220, 0.567769, 0.473853,
+        0.379548, 0.284933, 0.190084, 0.095081, 0.000000
+    };
+
+    double samples[100] = {0};
+    double duration = 400.0;
+    double points[3] = {-5.0, 0.0, 5.0};
+    int num_points = 3;
+    double epsilon = 0.00001;
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_interpolated_wf(
+                              NULL, duration, points, num_points));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_interpolated_wf(
+                              samples, duration, NULL, num_points));
+
+    double negative_duration = -1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_interpolated_wf(
+                              samples, negative_duration, points, num_points));
+
+    double too_short_duration = 5.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_interpolated_wf(
+                              samples, too_short_duration, points, num_points));
+
+    double too_long_duration = 1231411.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_interpolated_wf(
+                              samples, too_long_duration, points, num_points));
+
+    int neg_num_points = -42;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_interpolated_wf(
+                              samples, duration, points, neg_num_points));
+    int too_few_points = 1;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_interpolated_wf(
+                              samples, duration, points, too_few_points));
+    int too_many_points = 67;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_interpolated_wf(
+                              samples, duration, points, too_many_points));
+
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_interpolated_wf(
+                              samples, duration, points, num_points));
+    double sample_rate = 0.25;
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        double result = samples[i] - expected[i];
+        if (result < 0.0) result = -result;
+        TEST_ASSERT(result < epsilon);
+    }
+
+    points[0] = 1e-9;
+    points[1] = 3.1381;
+    points[2] = 1e-9;
+    cq_interpolated_wf(samples, duration, points, num_points);
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        double result = samples[i] - expected2[i];
+        if (result < 0.0) result = -result;
+        TEST_ASSERT(result < epsilon);
+    }
+}
+
+void test_cq_sech_wf(void) {
+    double expected[100] = {
+         8.33276632e-11, 1.37384091e-10, 2.26508073e-10, 3.73448677e-10,
+         6.15712778e-10, 1.01513875e-09, 1.67368086e-09, 2.75943323e-09,
+         4.54953626e-09, 7.50091720e-09, 1.23669217e-08, 2.03896069e-08,
+         3.36167786e-08, 5.54246980e-08, 9.13798785e-08, 1.50659949e-07,
+         2.48396263e-07, 4.09536203e-07, 6.75211048e-07, 1.11323482e-06,
+         1.83541392e-06, 3.02608598e-06, 4.98917231e-06, 8.22575452e-06,
+         1.35619764e-05, 2.23599190e-05, 3.68652741e-05, 6.07805616e-05,
+         1.00210205e-04, 1.65218696e-04, 2.72399578e-04, 4.49110977e-04,
+         7.40458813e-04, 1.22081016e-03, 2.01277554e-03, 3.31850521e-03,
+         5.47128724e-03, 9.02061477e-03, 1.48724217e-02, 2.45202191e-02,
+         4.04258467e-02, 6.66457545e-02, 1.09856980e-01, 1.81019232e-01,
+         2.97983782e-01, 4.89213696e-01, 7.97406687e-01, 1.27528810e+00,
+         1.94416282e+00, 2.66045665e+00, 3.00000000e+00, 2.66045665e+00,
+         1.94416282e+00, 1.27528810e+00, 7.97406687e-01, 4.89213696e-01,
+         2.97983782e-01, 1.81019232e-01, 1.09856980e-01, 6.66457545e-02,
+         4.04258467e-02, 2.45202191e-02, 1.48724217e-02, 9.02061477e-03,
+         5.47128724e-03, 3.31850521e-03, 2.01277554e-03, 1.22081016e-03,
+         7.40458813e-04, 4.49110977e-04, 2.72399578e-04, 1.65218696e-04,
+         1.00210205e-04, 6.07805616e-05, 3.68652741e-05, 2.23599190e-05,
+         1.35619764e-05, 8.22575452e-06, 4.98917231e-06, 3.02608598e-06,
+         1.83541392e-06, 1.11323482e-06, 6.75211048e-07, 4.09536203e-07,
+         2.48396263e-07, 1.50659949e-07, 9.13798785e-08, 5.54246980e-08,
+         3.36167786e-08, 2.03896069e-08, 1.23669217e-08, 7.50091720e-09,
+         4.54953626e-09, 2.75943323e-09, 1.67368086e-09, 1.01513875e-09,
+         6.15712778e-10, 3.73448677e-10, 2.26508073e-10, 1.37384091e-10
+    };
+
+    double samples[100] = {0};
+    double duration = 312.0;
+    double amp = 3.0;
+    double sigma = 2.0;
+    double epsilon = 0.0000001;
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_sech_wf(NULL, duration, amp, sigma));
+
+    double negative_duration = -1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_sech_wf(samples, negative_duration, amp, sigma));
+
+    double too_short_duration = 5.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_sech_wf(samples, too_short_duration, amp, sigma));
+
+    double too_long_duration = 1231411.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_sech_wf(samples, too_long_duration, amp, sigma));
+
+    duration = 400.0;
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_sech_wf(samples, duration, amp, sigma));
+
+    double sample_rate = 0.25;
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        TEST_ASSERT(samples[i] - expected[i] < epsilon);
+    }
+}
+
+void test_cq_sin_wf(void) {
+    double expected[100] = {
+          0.00000000e+00,  1.25333234e-01,  2.48689887e-01,  3.68124553e-01,
+          4.81753674e-01,  5.87785252e-01,  6.84547106e-01,  7.70513243e-01,
+          8.44327926e-01,  9.04827052e-01,  9.51056516e-01,  9.82287251e-01,
+          9.98026728e-01,  9.98026728e-01,  9.82287251e-01,  9.51056516e-01,
+          9.04827052e-01,  8.44327926e-01,  7.70513243e-01,  6.84547106e-01,
+          5.87785252e-01,  4.81753674e-01,  3.68124553e-01,  2.48689887e-01,
+          1.25333234e-01,  1.22464680e-16, -1.25333234e-01, -2.48689887e-01,
+         -3.68124553e-01, -4.81753674e-01, -5.87785252e-01, -6.84547106e-01,
+         -7.70513243e-01, -8.44327926e-01, -9.04827052e-01, -9.51056516e-01,
+         -9.82287251e-01, -9.98026728e-01, -9.98026728e-01, -9.82287251e-01,
+         -9.51056516e-01, -9.04827052e-01, -8.44327926e-01, -7.70513243e-01,
+         -6.84547106e-01, -5.87785252e-01, -4.81753674e-01, -3.68124553e-01,
+         -2.48689887e-01, -1.25333234e-01, -2.44929360e-16,  1.25333234e-01,
+          2.48689887e-01,  3.68124553e-01,  4.81753674e-01,  5.87785252e-01,
+          6.84547106e-01,  7.70513243e-01,  8.44327926e-01,  9.04827052e-01,
+          9.51056516e-01,  9.82287251e-01,  9.98026728e-01,  9.98026728e-01,
+          9.82287251e-01,  9.51056516e-01,  9.04827052e-01,  8.44327926e-01,
+          7.70513243e-01,  6.84547106e-01,  5.87785252e-01,  4.81753674e-01,
+          3.68124553e-01,  2.48689887e-01,  1.25333234e-01,  3.67394040e-16,
+         -1.25333234e-01, -2.48689887e-01, -3.68124553e-01, -4.81753674e-01,
+         -5.87785252e-01, -6.84547106e-01, -7.70513243e-01, -8.44327926e-01,
+         -9.04827052e-01, -9.51056516e-01, -9.82287251e-01, -9.98026728e-01,
+         -9.98026728e-01, -9.82287251e-01, -9.51056516e-01, -9.04827052e-01,
+         -8.44327926e-01, -7.70513243e-01, -6.84547106e-01, -5.87785252e-01,
+         -4.81753674e-01, -3.68124553e-01, -2.48689887e-01, -1.25333234e-01,
+    };
+
+    double samples[100] = {0};
+    double duration = 313.0;
+    double amp = 1.0;
+    double freq = 2.0;
+    double phase = 0.0;
+    double epsilon = 0.0000001;
+
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_sin_wf(samples, duration, amp, freq, phase));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_sin_wf(NULL, duration, amp, freq, phase));
+
+    double negative_duration = -1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_sin_wf(samples, negative_duration, amp, freq, phase));
+
+    double too_short_duration = 1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_sin_wf(samples, too_short_duration, amp, freq, phase));
+
+    double too_long_duration = 4000000001.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_sin_wf(samples, too_long_duration, amp, freq, phase));
+
+    double negative_freq = -1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_sin_wf(samples, duration, amp, negative_freq, phase));
+
+    duration = 400.0;
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, cq_sin_wf(samples, duration, amp, freq, phase));
+
+    double sample_rate = 0.25;
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        TEST_ASSERT(samples[i] - expected[i] < epsilon);
+    }
+}
+
+void test_cq_cos_wf(void) {
+    double expected[100] = {
+      1.        ,  0.9921147 ,  0.96858316,  0.92977649,  0.87630668,  0.80901699,
+      0.72896863,  0.63742399,  0.53582679,  0.42577929,  0.30901699,  0.18738131,
+      0.06279052, -0.06279052, -0.18738131, -0.30901699, -0.42577929, -0.53582679,
+     -0.63742399, -0.72896863, -0.80901699, -0.87630668, -0.92977649, -0.96858316,
+     -0.9921147 , -1.        , -0.9921147 , -0.96858316, -0.92977649, -0.87630668,
+     -0.80901699, -0.72896863, -0.63742399, -0.53582679, -0.42577929, -0.30901699,
+     -0.18738131, -0.06279052,  0.06279052,  0.18738131,  0.30901699,  0.42577929,
+      0.53582679,  0.63742399,  0.72896863,  0.80901699,  0.87630668,  0.92977649,
+      0.96858316,  0.9921147 ,  1.        ,  0.9921147 ,  0.96858316,  0.92977649,
+      0.87630668,  0.80901699,  0.72896863,  0.63742399,  0.53582679,  0.42577929,
+      0.30901699,  0.18738131,  0.06279052, -0.06279052, -0.18738131, -0.30901699,
+     -0.42577929, -0.53582679, -0.63742399, -0.72896863, -0.80901699, -0.87630668,
+     -0.92977649, -0.96858316, -0.9921147 , -1.        , -0.9921147 , -0.96858316,
+     -0.92977649, -0.87630668, -0.80901699, -0.72896863, -0.63742399, -0.53582679,
+     -0.42577929, -0.30901699, -0.18738131, -0.06279052,  0.06279052,  0.18738131,
+      0.30901699,  0.42577929,  0.53582679,  0.63742399,  0.72896863,  0.80901699,
+      0.87630668,  0.92977649,  0.96858316,  0.9921147
+    };
+    double samples[100] = {0};
+    double duration = 313.0;
+    double amp = 1.0;
+    double freq = 2.0;
+    double phase = 0.0;
+    double epsilon = 0.0000001;
+
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_cos_wf(samples, duration, amp, freq, phase));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_cos_wf(NULL, duration, amp, freq, phase));
+
+    double negative_duration = -1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_cos_wf(samples, negative_duration, amp, freq, phase));
+
+    double too_short_duration = 1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_cos_wf(samples, too_short_duration, amp, freq, phase));
+
+    double too_long_duration = 4000000001.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_cos_wf(samples, too_long_duration, amp, freq, phase));
+
+    double negative_freq = -1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_cos_wf(samples, duration, amp, negative_freq, phase));
+
+    duration = 400.0;
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, cq_cos_wf(samples, duration, amp, freq, phase));
+
+    double sample_rate = 0.25;
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        TEST_ASSERT(samples[i] - expected[i] < epsilon);
+    }
+}
+
+void test_cq_blackman_wf(void) {
+    double expected[100] = {
+         0.006879   , 0.00725287 , 0.00838017 , 0.01027784 , 0.01297364 , 0.01650552,
+         0.0209207  , 0.02627448 , 0.03262891 , 0.04005124 , 0.04861217 , 0.05838401,
+         0.06943873 , 0.0818459  , 0.09567068 , 0.11097171 , 0.12779913 , 0.14619264,
+         0.16617964 , 0.18777356 , 0.21097237 , 0.23575726 , 0.26209154 , 0.28991988,
+         0.31916772 , 0.349741   , 0.38152624 , 0.41439082 , 0.44818367 , 0.48273616,
+         0.51786333 , 0.55336542 , 0.58902957 , 0.62463185 , 0.65993944 , 0.694713  ,
+         0.72870919 , 0.76168332 , 0.79339205 , 0.82359612 , 0.85206313 , 0.87857019,
+         0.9029066  , 0.92487632 , 0.94430032 , 0.96101877 , 0.97489295 , 0.98580695,
+         0.99366912 , 0.99841317 , 0.999999   , 0.99841317 , 0.99366912 , 0.98580695,
+         0.97489295 , 0.96101877 , 0.94430032 , 0.92487632 , 0.9029066  , 0.87857019,
+         0.85206313 , 0.82359612 , 0.79339205 , 0.76168332 , 0.72870919 , 0.694713  ,
+         0.65993944 , 0.62463185 , 0.58902957 , 0.55336542 , 0.51786333 , 0.48273616,
+         0.44818367 , 0.41439082 , 0.38152624 , 0.349741   , 0.31916772 , 0.28991988,
+         0.26209154 , 0.23575726 , 0.21097237 , 0.18777356 , 0.16617964 , 0.14619264,
+         0.12779913 , 0.11097171 , 0.09567068 , 0.0818459  , 0.06943873 , 0.05838401,
+         0.04861217 , 0.04005124 , 0.03262891 , 0.02627448 , 0.0209207  , 0.01650552,
+         0.01297364 , 0.01027784 , 0.00838017 , 0.00725287
+    };
+    double samples[100] = {0};
+    double duration = 313.0;
+    double amp = 1.0;
+    double freq = 2.0;
+    double phase = 0.0;
+    double epsilon = 0.0000001;
+
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_blackman_wf(samples, duration, amp));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_blackman_wf(NULL, duration, amp));
+
+    double negative_duration = -1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_blackman_wf(samples, negative_duration, amp));
+
+    double too_short_duration = 1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_blackman_wf(samples, too_short_duration, amp));
+
+    double too_long_duration = 4000000001.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_blackman_wf(samples, too_long_duration, amp));
+
+    duration = 400.0;
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS, cq_blackman_wf(samples, duration, amp));
+
+    double sample_rate = 0.25;
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        TEST_ASSERT(samples[i] - expected[i] < epsilon);
+    }
+}
+
+void test_cq_saw_wf(void) {
+    double expected[100] = {
+          0.,    0.04,  0.08,  0.12,  0.16,  0.2 ,  0.24,  0.28,
+          0.32,  0.36,  0.4 ,  0.44,  0.48,  0.52,  0.56,  0.6 ,
+          0.64,  0.68,  0.72,  0.76,  0.8 ,  0.84,  0.88,  0.92,
+          0.96, -1.  , -0.96, -0.92, -0.88, -0.84, -0.8 , -0.76,
+          -0.72, -0.68, -0.64, -0.6 ,-0.56, -0.52, -0.48, -0.44,
+          -0.4 , -0.36, -0.32, -0.28, -0.24, -0.2 , -0.16, -0.12,
+          -0.08, -0.04,  0.  ,  0.04,  0.08,  0.12,  0.16,  0.2 ,
+          0.24,  0.28,  0.32,  0.36, 0.4 ,  0.44,  0.48,  0.52,
+          0.56,  0.6 ,  0.64,  0.68,  0.72,  0.76,  0.8 ,  0.84,
+          0.88,  0.92,  0.96, -1.  , -0.96, -0.92, -0.88, -0.84,
+          -0.8 , -0.76, -0.72, -0.68, -0.64, -0.6 , -0.56, -0.52,
+          -0.48, -0.44, -0.4 , -0.36, -0.32, -0.28, -0.24, -0.2 ,
+          -0.16, -0.12, -0.08, -0.04
+    };
+
+    double samples[100] = {0};
+    double duration = 313.0;
+    double amp = 1.0;
+    double freq = 2.0;
+    double phase = 0.0;
+    double epsilon = 0.0000001;
+
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_saw_wf(samples, duration, amp, freq, phase));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_saw_wf(NULL, duration, amp, freq, phase));
+
+    double negative_duration = -1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_saw_wf(samples, negative_duration, amp, freq, phase));
+
+    double too_short_duration = 1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_saw_wf(samples, too_short_duration, amp, freq, phase));
+
+    double too_long_duration = 4000000001.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_saw_wf(samples, too_long_duration, amp, freq, phase));
+
+    double negative_freq = -1.0;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_saw_wf(samples, duration, amp, negative_freq, phase));
+
+    duration = 400.0;
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_saw_wf(samples, duration, amp, freq, phase));
+
+    double sample_rate = 0.25;
+    ptrdiff_t num_samples = (ptrdiff_t)(duration * sample_rate);
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        TEST_ASSERT(samples[i] - expected[i] < epsilon);
+    }
+}
+
+void test_cq_custom_wf(void) {
+    double samples[100] = {0};
+    double values[100] = {
+        0 , 1 , 2 , 3 , 4 , 5 , 6 , 7 , 8 , 9 , 10,
+        11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+        31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+        41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+        51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+        61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
+        71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+        81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
+        91, 92, 93, 94, 95, 96, 97, 98, 99
+    };
+    double epsilon = 0.0000001;
+    int num_samples = 100;
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_custom_wf(NULL, values, num_samples));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_custom_wf(samples, NULL, num_samples));
+
+
+    double values_diff_size[4] = {0, 1, 2, 3};
+    int values_size = 4;
+     TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_custom_wf(samples, values_diff_size, values_size));
+
+
+    int neg_num_samples = -1;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_custom_wf(samples, values, neg_num_samples));
+
+    int too_few_samples = 1;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_custom_wf(samples, values, too_few_samples));
+
+    ptrdiff_t too_many_samples = 124444444444;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                          cq_custom_wf(samples, values, too_many_samples));
+
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                          cq_custom_wf(samples, values, num_samples));
+
+    for (ptrdiff_t i = 0; i < num_samples; ++i) {
+        TEST_ASSERT(samples[i] - values[i] < epsilon);
+    }
+}
+void test_cq_composite_wf(void) {
+    double expected[300] = {
+      5.31236408e-242,  1.90443622e-232,  4.37749104e-223,  6.45155387e-214,
+      6.09654271e-205,  3.69388307e-196,  1.43503633e-187,  3.57456238e-179,
+      5.70904011e-171,  5.84633286e-163,  3.83870035e-155,  1.61608841e-147,
+      4.36240770e-140,  7.55035926e-133,  8.37894253e-126,  5.96198717e-119,
+      2.72002624e-112,  7.95674389e-106,  1.49237476e-099,  1.79473628e-093,
+      1.38389653e-087,  6.84205918e-082,  2.16895361e-076,  4.40853133e-071,
+      5.74536772e-066,  4.80089224e-061,  2.57220937e-056,  8.83630922e-052,
+      1.94632663e-047,  2.74878501e-043,  2.48912125e-039,  1.44521201e-035,
+      5.38018616e-032,  1.28423137e-028,  1.96548382e-025,  1.92874985e-022,
+      1.21356367e-019,  4.89586526e-017,  1.26641655e-014,  2.10040929e-012,
+      2.23363144e-010,  1.52299797e-008,  6.65836147e-007,  1.86644691e-005,
+      3.35462628e-004,  3.86592014e-003,  2.85655008e-002,  1.35335283e-001,
+      4.11112291e-001,  8.00737403e-001,  1.00000000e+000,  8.00737403e-001,
+      4.11112291e-001,  1.35335283e-001,  2.85655008e-002,  3.86592014e-003,
+      3.35462628e-004,  1.86644691e-005,  6.65836147e-007,  1.52299797e-008,
+      2.23363144e-010,  2.10040929e-012,  1.26641655e-014,  4.89586526e-017,
+      1.21356367e-019,  1.92874985e-022,  1.96548382e-025,  1.28423137e-028,
+      5.38018616e-032,  1.44521201e-035,  2.48912125e-039,  2.74878501e-043,
+      1.94632663e-047,  8.83630922e-052,  2.57220937e-056,  4.80089224e-061,
+      5.74536772e-066,  4.40853133e-071,  2.16895361e-076,  6.84205918e-082,
+      1.38389653e-087,  1.79473628e-093,  1.49237476e-099,  7.95674389e-106,
+      2.72002624e-112,  5.96198717e-119,  8.37894253e-126,  7.55035926e-133,
+      4.36240770e-140,  1.61608841e-147,  3.83870035e-155,  5.84633286e-163,
+      5.70904011e-171,  3.57456238e-179,  1.43503633e-187,  3.69388307e-196,
+      6.09654271e-205,  6.45155387e-214,  4.37749104e-223,  1.90443622e-232,
+      0.00000000e+000,  1.25333234e-001,  2.48689887e-001,  3.68124553e-001,
+      4.81753674e-001,  5.87785252e-001,  6.84547106e-001,  7.70513243e-001,
+      8.44327926e-001,  9.04827052e-001,  9.51056516e-001,  9.82287251e-001,
+      9.98026728e-001,  9.98026728e-001,  9.82287251e-001,  9.51056516e-001,
+      9.04827052e-001,  8.44327926e-001,  7.70513243e-001,  6.84547106e-001,
+      5.87785252e-001,  4.81753674e-001,  3.68124553e-001,  2.48689887e-001,
+      1.25333234e-001,  1.22464680e-016, -1.25333234e-001, -2.48689887e-001,
+     -3.68124553e-001, -4.81753674e-001, -5.87785252e-001, -6.84547106e-001,
+     -7.70513243e-001, -8.44327926e-001, -9.04827052e-001, -9.51056516e-001,
+     -9.82287251e-001, -9.98026728e-001, -9.98026728e-001, -9.82287251e-001,
+     -9.51056516e-001, -9.04827052e-001, -8.44327926e-001, -7.70513243e-001,
+     -6.84547106e-001, -5.87785252e-001, -4.81753674e-001, -3.68124553e-001,
+     -2.48689887e-001, -1.25333234e-001, -2.44929360e-016,  1.25333234e-001,
+      2.48689887e-001,  3.68124553e-001,  4.81753674e-001,  5.87785252e-001,
+      6.84547106e-001,  7.70513243e-001,  8.44327926e-001,  9.04827052e-001,
+      9.51056516e-001,  9.82287251e-001,  9.98026728e-001,  9.98026728e-001,
+      9.82287251e-001,  9.51056516e-001,  9.04827052e-001,  8.44327926e-001,
+      7.70513243e-001,  6.84547106e-001,  5.87785252e-001,  4.81753674e-001,
+      3.68124553e-001,  2.48689887e-001,  1.25333234e-001,  3.67394040e-016,
+     -1.25333234e-001, -2.48689887e-001, -3.68124553e-001, -4.81753674e-001,
+     -5.87785252e-001, -6.84547106e-001, -7.70513243e-001, -8.44327926e-001,
+     -9.04827052e-001, -9.51056516e-001, -9.82287251e-001, -9.98026728e-001,
+     -9.98026728e-001, -9.82287251e-001, -9.51056516e-001, -9.04827052e-001,
+     -8.44327926e-001, -7.70513243e-001, -6.84547106e-001, -5.87785252e-001,
+     -4.81753674e-001, -3.68124553e-001, -2.48689887e-001, -1.25333234e-001,
+      1.00000000e+000,  9.92114701e-001,  9.68583161e-001,  9.29776486e-001,
+      8.76306680e-001,  8.09016994e-001,  7.28968627e-001,  6.37423990e-001,
+      5.35826795e-001,  4.25779292e-001,  3.09016994e-001,  1.87381315e-001,
+      6.27905195e-002, -6.27905195e-002, -1.87381315e-001, -3.09016994e-001,
+     -4.25779292e-001, -5.35826795e-001, -6.37423990e-001, -7.28968627e-001,
+     -8.09016994e-001, -8.76306680e-001, -9.29776486e-001, -9.68583161e-001,
+     -9.92114701e-001, -1.00000000e+000, -9.92114701e-001, -9.68583161e-001,
+     -9.29776486e-001, -8.76306680e-001, -8.09016994e-001, -7.28968627e-001,
+     -6.37423990e-001, -5.35826795e-001, -4.25779292e-001, -3.09016994e-001,
+     -1.87381315e-001, -6.27905195e-002,  6.27905195e-002,  1.87381315e-001,
+      3.09016994e-001,  4.25779292e-001,  5.35826795e-001,  6.37423990e-001,
+      7.28968627e-001,  8.09016994e-001,  8.76306680e-001,  9.29776486e-001,
+      9.68583161e-001,  9.92114701e-001,  1.00000000e+000,  9.92114701e-001,
+      9.68583161e-001,  9.29776486e-001,  8.76306680e-001,  8.09016994e-001,
+      7.28968627e-001,  6.37423990e-001,  5.35826795e-001,  4.25779292e-001,
+      3.09016994e-001,  1.87381315e-001,  6.27905195e-002, -6.27905195e-002,
+     -1.87381315e-001, -3.09016994e-001, -4.25779292e-001, -5.35826795e-001,
+     -6.37423990e-001, -7.28968627e-001, -8.09016994e-001, -8.76306680e-001,
+     -9.29776486e-001, -9.68583161e-001, -9.92114701e-001, -1.00000000e+000,
+     -9.92114701e-001, -9.68583161e-001, -9.29776486e-001, -8.76306680e-001,
+     -8.09016994e-001, -7.28968627e-001, -6.37423990e-001, -5.35826795e-001,
+     -4.25779292e-001, -3.09016994e-001, -1.87381315e-001, -6.27905195e-002,
+      6.27905195e-002,  1.87381315e-001,  3.09016994e-001,  4.25779292e-001,
+      5.35826795e-001,  6.37423990e-001,  7.28968627e-001,  8.09016994e-001,
+      8.76306680e-001,  9.29776486e-001,  9.68583161e-001,  9.92114701e-001,
+    };
+
+    double gaussian_wav[100] = {0};
+    double sin_wav[100] = {0};
+    double cos_wav[100] = {0};
+    double composite_wav[300];
+    double duration = 400.0;
+    double amp = 1.0;
+    double sigma = 1.5;
+    double freq = 2.0;
+    double epsilon = 0.0000001;
+
+    cq_gaussian_wf(gaussian_wav, duration, amp, sigma);
+    cq_sin_wf(sin_wav, duration, amp, freq, 0.0);
+    cq_cos_wf(cos_wav, duration, amp, freq, 0.0);
+    double *waveforms[3] = {gaussian_wav, sin_wav, cos_wav};
+
+    ptrdiff_t num_samples[3] = {100, 100, 100};
+    int num_waveforms = 3;
+    ptrdiff_t total_num_samples = 0;
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                            cq_composite_wf(NULL, waveforms,
+                                num_samples, num_waveforms,
+                                &total_num_samples));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                            cq_composite_wf(composite_wav, NULL,
+                                num_samples, num_waveforms,
+                                &total_num_samples));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                            cq_composite_wf(composite_wav, waveforms,
+                                NULL, num_waveforms,
+                                &total_num_samples));
+
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                            cq_composite_wf(composite_wav, waveforms,
+                                num_samples, num_waveforms,
+                                NULL));
+
+    ptrdiff_t neg_num_samples[3] = {-24, 5, 5};
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                            cq_composite_wf(composite_wav, waveforms,
+                                neg_num_samples, num_waveforms,
+                                &total_num_samples));
+
+    int neg_num_waveforms = -1;
+    TEST_ASSERT_EQUAL_INT(CQ_ERROR,
+                            cq_composite_wf(composite_wav, waveforms,
+                                num_samples, neg_num_waveforms,
+                                &total_num_samples));
+
+
+
+    TEST_ASSERT_EQUAL_INT(CQ_SUCCESS,
+                cq_composite_wf(composite_wav, waveforms,
+                                num_samples, num_waveforms,
+                                &total_num_samples));
+
+    for (ptrdiff_t i = 0; i < total_num_samples; ++i) {
+        TEST_ASSERT(composite_wav[i] - expected[i] < epsilon);
+    }
+}
+
+// not needed when using generate_test_runner.rb
+int main(void) {
+    setUp();
+    UNITY_BEGIN();
+    RUN_TEST(test_cq_gaussian_wf);
+    RUN_TEST(test_cq_gaussian_sqr_wf);
+    RUN_TEST(test_cq_interpolated_wf);
+    RUN_TEST(test_cq_sech_wf);
+    RUN_TEST(test_cq_sin_wf);
+    RUN_TEST(test_cq_cos_wf);
+    RUN_TEST(test_cq_blackman_wf);
+    RUN_TEST(test_cq_saw_wf);
+    RUN_TEST(test_cq_custom_wf);
+    RUN_TEST(test_cq_composite_wf);
+    return UNITY_END();
+}


### PR DESCRIPTION
# Introducing analogue extension to CQ.

## Users can:
- enable analogue capabilities to quantum registers from within quantum kernel
- select channels which operate on qubits
- define pulses via collection of supplied waveforms
- play pulses
- use pulses to capture data (emulate quantum measurement)
- delay channels
- synchronise channels

## Future work:
- add support for other quantum platforms
- allow users to configure own analogue devices